### PR TITLE
feat: harden tool-calling flow and validate custom skill schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.5] - 2026-02-27
+
+### Fixed
+- Restored tool definition delivery in chat mode so skill/function metadata is sent from the live LLM client instead of the TUI skills panel stub.
+- Added multi-tool execution flow support: all tool calls returned in a single assistant turn are now executed and replied with matching `tool_call_id` results before continuation.
+- Hardened tool argument parsing so malformed JSON arguments surface as explicit tool errors rather than silently falling back to empty argument maps.
+
+### Changed
+- Added schema validation for disk-loaded custom skills to reject malformed function definitions before they reach provider APIs.
+- Hardened OpenAI/xAI tool serialization by skipping invalid tool payloads gracefully instead of sending malformed definitions.
+- Improved Google/Vertex schema conversion compatibility for `required` fields across both `[]string` and `[]interface{}` input forms.
+
+### Testing
+- Added regression coverage for:
+  - custom skill schema validation pass/fail paths
+  - OpenAI and xAI tool serialization skip-on-error behavior
+  - Google/Vertex `required` schema conversion compatibility
+  - multi-tool TUI execution sequencing and single follow-up request semantics
+
 ## [1.5.4] - 2026-02-25
 
 ### Security

--- a/cmd/celeste/llm/backend_google.go
+++ b/cmd/celeste/llm/backend_google.go
@@ -370,11 +370,14 @@ func (b *GoogleBackend) convertSchemaToGenAI(params map[string]interface{}) *gen
 	}
 
 	// Extract required fields
-	if required, ok := params["required"].([]interface{}); ok {
-		requiredStrs := make([]string, len(required))
-		for i, v := range required {
-			if str, ok := v.(string); ok {
-				requiredStrs[i] = str
+	switch required := params["required"].(type) {
+	case []string:
+		schema.Required = required
+	case []interface{}:
+		requiredStrs := make([]string, 0, len(required))
+		for _, v := range required {
+			if str, ok := v.(string); ok && str != "" {
+				requiredStrs = append(requiredStrs, str)
 			}
 		}
 		schema.Required = requiredStrs

--- a/cmd/celeste/llm/backend_google_test.go
+++ b/cmd/celeste/llm/backend_google_test.go
@@ -1,0 +1,42 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoogleConvertSchemaRequiredFromStringSlice(t *testing.T) {
+	backend := &GoogleBackend{}
+
+	schema := backend.convertSchemaToGenAI(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"location": map[string]interface{}{
+				"type": "string",
+			},
+		},
+		"required": []string{"location"},
+	})
+
+	require.NotNil(t, schema)
+	assert.Equal(t, []string{"location"}, schema.Required)
+}
+
+func TestGoogleConvertSchemaRequiredFromInterfaceSlice(t *testing.T) {
+	backend := &GoogleBackend{}
+
+	schema := backend.convertSchemaToGenAI(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"location": map[string]interface{}{
+				"type": "string",
+			},
+		},
+		"required": []interface{}{"location"},
+	})
+
+	require.NotNil(t, schema)
+	assert.Equal(t, []string{"location"}, schema.Required)
+}

--- a/cmd/celeste/llm/backend_openai.go
+++ b/cmd/celeste/llm/backend_openai.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/sashabaranov/go-openai"
@@ -347,7 +348,11 @@ func (b *OpenAIBackend) convertTools(tools []tui.SkillDefinition) []openai.Tool 
 
 	// Add user-defined function tools
 	for _, tool := range tools {
-		params, _ := json.Marshal(tool.Parameters)
+		params, err := json.Marshal(tool.Parameters)
+		if err != nil {
+			tui.LogInfo(fmt.Sprintf("Skipping invalid tool '%s': failed to marshal parameters: %v", tool.Name, err))
+			continue
+		}
 
 		result = append(result, openai.Tool{
 			Type: "function",

--- a/cmd/celeste/llm/backend_openai_test.go
+++ b/cmd/celeste/llm/backend_openai_test.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/whykusanagi/celeste-cli/cmd/celeste/tui"
+)
+
+func TestOpenAIConvertToolsSuccess(t *testing.T) {
+	backend := NewOpenAIBackend(&Config{})
+
+	tools := backend.convertTools([]tui.SkillDefinition{
+		{
+			Name:        "echo",
+			Description: "Echo text",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"text": map[string]any{"type": "string"},
+				},
+			},
+		},
+	})
+
+	require.Len(t, tools, 1)
+	require.NotNil(t, tools[0].Function)
+	assert.Equal(t, "echo", tools[0].Function.Name)
+}
+
+func TestOpenAIConvertToolsSkipsMarshalErrors(t *testing.T) {
+	backend := NewOpenAIBackend(&Config{})
+
+	tools := backend.convertTools([]tui.SkillDefinition{
+		{
+			Name:        "valid_tool",
+			Description: "Valid",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "bad_tool",
+			Description: "Invalid params",
+			Parameters: map[string]any{
+				"bad": func() {},
+			},
+		},
+	})
+
+	require.Len(t, tools, 1, "invalid tool should be skipped")
+	require.NotNil(t, tools[0].Function)
+	assert.Equal(t, "valid_tool", tools[0].Function.Name)
+}

--- a/cmd/celeste/llm/backend_xai.go
+++ b/cmd/celeste/llm/backend_xai.go
@@ -334,7 +334,11 @@ func (b *XAIBackend) convertTools(tools []tui.SkillDefinition) []xAITool {
 	var result []xAITool
 
 	for _, tool := range tools {
-		params, _ := json.Marshal(tool.Parameters)
+		params, err := json.Marshal(tool.Parameters)
+		if err != nil {
+			tui.LogInfo(fmt.Sprintf("Skipping invalid tool '%s': failed to marshal parameters: %v", tool.Name, err))
+			continue
+		}
 
 		xaiTool := xAITool{
 			Type: "function",

--- a/cmd/celeste/llm/backend_xai_convert_test.go
+++ b/cmd/celeste/llm/backend_xai_convert_test.go
@@ -1,0 +1,53 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/whykusanagi/celeste-cli/cmd/celeste/tui"
+)
+
+func TestXAIConvertToolsSuccess(t *testing.T) {
+	backend := &XAIBackend{}
+
+	tools := backend.convertTools([]tui.SkillDefinition{
+		{
+			Name:        "echo",
+			Description: "Echo text",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	})
+
+	require.Len(t, tools, 1)
+	assert.Equal(t, "function", tools[0].Type)
+	assert.Equal(t, "echo", tools[0].Function.Name)
+}
+
+func TestXAIConvertToolsSkipsMarshalErrors(t *testing.T) {
+	backend := &XAIBackend{}
+
+	tools := backend.convertTools([]tui.SkillDefinition{
+		{
+			Name:        "valid_tool",
+			Description: "Valid",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "bad_tool",
+			Description: "Invalid params",
+			Parameters: map[string]any{
+				"bad": func() {},
+			},
+		},
+	})
+
+	require.Len(t, tools, 1)
+	assert.Equal(t, "valid_tool", tools[0].Function.Name)
+}

--- a/cmd/celeste/main_test.go
+++ b/cmd/celeste/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgsValidJSON(t *testing.T) {
+	args, err := parseArgs(`{"zip_code":"10001","days":2}`)
+	require.NoError(t, err)
+	assert.Equal(t, "10001", args["zip_code"])
+	assert.Equal(t, float64(2), args["days"])
+}
+
+func TestParseArgsInvalidJSON(t *testing.T) {
+	args, err := parseArgs(`{"zip_code":}`)
+	require.Error(t, err)
+	assert.Empty(t, args)
+}

--- a/cmd/celeste/skills/registry.go
+++ b/cmd/celeste/skills/registry.go
@@ -90,6 +90,10 @@ func (r *Registry) loadSkillFile(path string) error {
 		return fmt.Errorf("skill name is required")
 	}
 
+	if err := ValidateSkillDefinition(skill); err != nil {
+		return fmt.Errorf("invalid skill definition: %w", err)
+	}
+
 	r.skills[skill.Name] = skill
 	return nil
 }
@@ -157,6 +161,10 @@ func (r *Registry) HasHandler(name string) bool {
 
 // SaveSkill saves a skill definition to the skills directory.
 func (r *Registry) SaveSkill(skill Skill) error {
+	if err := ValidateSkillDefinition(skill); err != nil {
+		return fmt.Errorf("invalid skill definition: %w", err)
+	}
+
 	// Ensure directory exists
 	if err := os.MkdirAll(r.skillsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create skills directory: %w", err)

--- a/cmd/celeste/skills/validation.go
+++ b/cmd/celeste/skills/validation.go
@@ -1,0 +1,104 @@
+package skills
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var skillNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+var allowedJSONTypes = map[string]struct{}{
+	"string":  {},
+	"number":  {},
+	"integer": {},
+	"boolean": {},
+	"object":  {},
+	"array":   {},
+}
+
+// ValidateSkillDefinition validates a skill structure before exposing it as a tool.
+func ValidateSkillDefinition(skill Skill) error {
+	name := strings.TrimSpace(skill.Name)
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("skill name must match %s", skillNamePattern.String())
+	}
+
+	if strings.TrimSpace(skill.Description) == "" {
+		return fmt.Errorf("skill description is required")
+	}
+
+	if skill.Parameters == nil {
+		return fmt.Errorf("skill parameters are required")
+	}
+
+	paramType, ok := skill.Parameters["type"].(string)
+	if !ok || paramType != "object" {
+		return fmt.Errorf("skill parameters.type must be 'object'")
+	}
+
+	propertiesRaw, ok := skill.Parameters["properties"]
+	if !ok {
+		return fmt.Errorf("skill parameters.properties is required")
+	}
+
+	properties, ok := propertiesRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("skill parameters.properties must be an object")
+	}
+
+	for propName, propRaw := range properties {
+		propMap, ok := propRaw.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("property '%s' must be an object", propName)
+		}
+
+		propType, ok := propMap["type"].(string)
+		if !ok || propType == "" {
+			return fmt.Errorf("property '%s' must define a string type", propName)
+		}
+
+		if _, ok := allowedJSONTypes[propType]; !ok {
+			return fmt.Errorf("property '%s' has unsupported type '%s'", propName, propType)
+		}
+	}
+
+	requiredFields, err := parseRequiredFields(skill.Parameters["required"])
+	if err != nil {
+		return err
+	}
+
+	for _, required := range requiredFields {
+		if _, exists := properties[required]; !exists {
+			return fmt.Errorf("required field '%s' is not declared in properties", required)
+		}
+	}
+
+	return nil
+}
+
+func parseRequiredFields(requiredRaw interface{}) ([]string, error) {
+	if requiredRaw == nil {
+		return nil, nil
+	}
+
+	switch required := requiredRaw.(type) {
+	case []string:
+		return required, nil
+	case []interface{}:
+		result := make([]string, 0, len(required))
+		for i, field := range required {
+			str, ok := field.(string)
+			if !ok {
+				return nil, fmt.Errorf("required[%d] must be a string", i)
+			}
+			result = append(result, str)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("skill parameters.required must be an array of strings")
+	}
+}

--- a/cmd/celeste/skills/validation_test.go
+++ b/cmd/celeste/skills/validation_test.go
@@ -1,0 +1,124 @@
+package skills
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSkillDefinition(t *testing.T) {
+	valid := Skill{
+		Name:        "test_skill",
+		Description: "Valid test skill",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"required": []string{"input"},
+		},
+	}
+
+	require.NoError(t, ValidateSkillDefinition(valid))
+
+	invalid := valid
+	invalid.Parameters = map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"input": map[string]interface{}{
+				"type": "string",
+			},
+		},
+		"required": []string{"missing_field"},
+	}
+	require.Error(t, ValidateSkillDefinition(invalid))
+}
+
+func TestLoadSkillsSkipsInvalidCustomSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	registry := NewRegistry()
+	registry.SetSkillsDir(tmpDir)
+
+	invalid := Skill{
+		Name:        "broken_skill",
+		Description: "Missing parameters.type",
+		Parameters: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"value": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"required": []string{"value"},
+		},
+	}
+
+	data, err := json.Marshal(invalid)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "broken_skill.json"), data, 0644)
+	require.NoError(t, err)
+
+	err = registry.LoadSkills()
+	require.NoError(t, err)
+
+	_, exists := registry.GetSkill("broken_skill")
+	assert.False(t, exists, "invalid custom skill should be skipped")
+}
+
+func TestLoadSkillsLoadsValidCustomSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	registry := NewRegistry()
+	registry.SetSkillsDir(tmpDir)
+
+	valid := Skill{
+		Name:        "custom_echo",
+		Description: "Echoes back user input",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"text": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"required": []string{"text"},
+		},
+	}
+
+	data, err := json.Marshal(valid)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "custom_echo.json"), data, 0644)
+	require.NoError(t, err)
+
+	err = registry.LoadSkills()
+	require.NoError(t, err)
+
+	loaded, exists := registry.GetSkill("custom_echo")
+	require.True(t, exists, "valid custom skill should load")
+	assert.Equal(t, "custom_echo", loaded.Name)
+}
+
+func TestSaveSkillRejectsInvalidSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	registry := NewRegistry()
+	registry.SetSkillsDir(tmpDir)
+
+	err := registry.SaveSkill(Skill{
+		Name:        "bad_save",
+		Description: "Bad schema",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"value": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"required": []string{"unknown"},
+		},
+	})
+	require.Error(t, err)
+}

--- a/cmd/celeste/tui/messages.go
+++ b/cmd/celeste/tui/messages.go
@@ -76,6 +76,20 @@ type SkillCallMsg struct {
 	ToolCalls        []ToolCallInfo // All tool calls from the assistant message
 }
 
+// SkillCallRequest represents one tool call request in a batch.
+type SkillCallRequest struct {
+	Call       FunctionCall
+	ToolCallID string // OpenAI tool call ID for sending result back
+	ParseError string // Non-empty when arguments failed to parse
+}
+
+// SkillCallBatchMsg is sent when the LLM requests one or more skill/function calls.
+type SkillCallBatchMsg struct {
+	Calls            []SkillCallRequest
+	AssistantContent string         // Assistant message content (may be empty if only tool calls)
+	ToolCalls        []ToolCallInfo // Raw tool call payloads from assistant message
+}
+
 // SkillResultMsg is sent when a skill execution completes.
 type SkillResultMsg struct {
 	Name       string

--- a/cmd/celeste/tui/tool_calls_test.go
+++ b/cmd/celeste/tui/tool_calls_test.go
@@ -1,0 +1,153 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type execCall struct {
+	name       string
+	args       map[string]any
+	toolCallID string
+}
+
+type sendCall struct {
+	messageCount int
+	toolCount    int
+}
+
+type fakeToolLLMClient struct {
+	skills       []SkillDefinition
+	executeCalls []execCall
+	sendCalls    []sendCall
+}
+
+func (f *fakeToolLLMClient) SendMessage(messages []ChatMessage, tools []SkillDefinition) tea.Cmd {
+	f.sendCalls = append(f.sendCalls, sendCall{
+		messageCount: len(messages),
+		toolCount:    len(tools),
+	})
+	return nil
+}
+
+func (f *fakeToolLLMClient) GetSkills() []SkillDefinition {
+	return f.skills
+}
+
+func (f *fakeToolLLMClient) ExecuteSkill(name string, args map[string]any, toolCallID string) tea.Cmd {
+	f.executeCalls = append(f.executeCalls, execCall{
+		name:       name,
+		args:       args,
+		toolCallID: toolCallID,
+	})
+	return func() tea.Msg { return nil }
+}
+
+func TestSkillCallBatchExecutesSequentiallyAndSendsOneFollowUp(t *testing.T) {
+	client := &fakeToolLLMClient{
+		skills: []SkillDefinition{
+			{Name: "tool_a", Description: "A"},
+			{Name: "tool_b", Description: "B"},
+		},
+	}
+
+	m := NewApp(client)
+	m.skillsEnabled = true
+
+	batch := SkillCallBatchMsg{
+		Calls: []SkillCallRequest{
+			{
+				Call:       FunctionCall{Name: "tool_a", Arguments: map[string]any{"x": "1"}, Status: "executing"},
+				ToolCallID: "call_a",
+			},
+			{
+				Call:       FunctionCall{Name: "tool_b", Arguments: map[string]any{"y": "2"}, Status: "executing"},
+				ToolCallID: "call_b",
+			},
+		},
+		AssistantContent: "thinking",
+		ToolCalls: []ToolCallInfo{
+			{ID: "call_a", Name: "tool_a", Arguments: `{"x":"1"}`},
+			{ID: "call_b", Name: "tool_b", Arguments: `{"y":"2"}`},
+		},
+	}
+
+	model, _ := m.Update(batch)
+	m = model.(AppModel)
+	require.Len(t, client.executeCalls, 1)
+	assert.Equal(t, "tool_a", client.executeCalls[0].name)
+	assert.Len(t, client.sendCalls, 0)
+
+	model, _ = m.Update(SkillResultMsg{Name: "tool_a", Result: `{"ok":true}`, ToolCallID: "call_a"})
+	m = model.(AppModel)
+	require.Len(t, client.executeCalls, 2)
+	assert.Equal(t, "tool_b", client.executeCalls[1].name)
+	assert.Len(t, client.sendCalls, 0)
+
+	model, _ = m.Update(SkillResultMsg{Name: "tool_b", Result: `{"ok":true}`, ToolCallID: "call_b"})
+	m = model.(AppModel)
+	require.Len(t, client.sendCalls, 1, "follow-up should be sent once after the final tool result")
+	assert.Equal(t, 2, client.sendCalls[0].toolCount)
+
+	messages := m.chat.GetMessages()
+	assistantWithCalls := 0
+	toolMessages := 0
+	for _, msg := range messages {
+		if msg.Role == "assistant" && len(msg.ToolCalls) == 2 {
+			assistantWithCalls++
+		}
+		if msg.Role == "tool" {
+			toolMessages++
+		}
+	}
+	assert.Equal(t, 1, assistantWithCalls)
+	assert.Equal(t, 2, toolMessages)
+}
+
+func TestSkillCallBatchParseErrorProducesExplicitToolError(t *testing.T) {
+	client := &fakeToolLLMClient{
+		skills: []SkillDefinition{
+			{Name: "tool_a", Description: "A"},
+		},
+	}
+
+	m := NewApp(client)
+	m.skillsEnabled = true
+
+	model, cmd := m.Update(SkillCallBatchMsg{
+		Calls: []SkillCallRequest{
+			{
+				Call:       FunctionCall{Name: "tool_a", Arguments: map[string]any{}, Status: "executing"},
+				ToolCallID: "call_bad",
+				ParseError: "invalid character '}' looking for beginning of object key string",
+			},
+		},
+		AssistantContent: "thinking",
+		ToolCalls: []ToolCallInfo{
+			{ID: "call_bad", Name: "tool_a", Arguments: `{"bad":}`},
+		},
+	})
+	m = model.(AppModel)
+
+	require.NotNil(t, cmd)
+	parseErrMsg := cmd()
+
+	model, _ = m.Update(parseErrMsg)
+	m = model.(AppModel)
+
+	assert.Len(t, client.executeCalls, 0, "parse failure should not call ExecuteSkill")
+	require.Len(t, client.sendCalls, 1, "conversation should continue with one follow-up after tool error")
+	assert.Equal(t, 1, client.sendCalls[0].toolCount)
+
+	foundError := false
+	for _, msg := range m.chat.GetMessages() {
+		if msg.Role == "tool" && msg.ToolCallID == "call_bad" {
+			foundError = true
+			assert.Contains(t, msg.Content, `"error": true`)
+		}
+	}
+	assert.True(t, foundError, "tool error result should be added to chat history")
+}

--- a/docs/plans/2026-02-27-openai-skill-compat-hardening.md
+++ b/docs/plans/2026-02-27-openai-skill-compat-hardening.md
@@ -1,0 +1,103 @@
+# OpenAI Skill Compatibility Hardening Plan (xAI/Vertex Safe)
+
+## Summary
+This document captures the tool-calling reliability issues found in Celeste CLI and the implementation strategy to fix them without breaking xAI or Vertex functionality.
+
+Version target: `1.5.5`  
+Branch: `codex/openai-skill-hardening`
+
+## Findings (Severity + References)
+
+### P0: Tool definitions not sent from TUI chat path
+- TUI chat used `m.skills.GetDefinitions()` (skills panel stub) which always returned an empty list.
+- Result: providers received no user skill definitions, so function calling was effectively disabled in normal chat.
+- References:
+  - `cmd/celeste/tui/app.go` (skills panel stub and send path)
+
+### P1: Only first tool call executed
+- Streaming handler captured all tool calls but only dispatched the first call in a turn.
+- Result: multi-tool turns from OpenAI-compatible providers were partially executed.
+- References:
+  - `cmd/celeste/main.go` tool call dispatch logic
+  - `cmd/celeste/tui/app.go` skill result continuation flow
+
+### P1: Missing validation for disk-loaded custom skills
+- Custom skills loaded from `~/.celeste/skills/*.json` only validated `name`.
+- Result: malformed schemas could be forwarded to provider APIs and fail requests.
+- References:
+  - `cmd/celeste/skills/registry.go`
+
+### P2: Serialization and argument parsing errors were masked
+- Tool parameter marshal errors were ignored.
+- Tool argument JSON parse errors silently fell back to `{}`.
+- Result: lower observability and misleading downstream errors.
+- References:
+  - `cmd/celeste/llm/backend_openai.go`
+  - `cmd/celeste/llm/backend_xai.go`
+  - `cmd/celeste/main.go`
+
+## Root Cause Analysis
+1. The TUI skills panel implementation is a rendering stub and not a source of runtime tool definitions.
+2. Tool dispatch logic assumed one tool call per turn despite providers returning arrays.
+3. Skill schema trust boundary was too permissive for filesystem-loaded JSON.
+4. Error handling favored silent fallback over explicit fail-fast or structured reporting.
+
+## Provider Compatibility Constraints
+
+### OpenAI
+- Must receive complete `tools` definitions for function calling.
+- Must receive assistant `tool_calls` message followed by one `tool` response per `tool_call_id`.
+
+### xAI
+- Native backend and Collections (`collection_ids`) request shape must remain unchanged.
+- Tool conversion hardening should only skip invalid user-defined function tools, not built-in xAI behavior.
+
+### Vertex (Google backend)
+- Native auth/bootstrap flow must remain unchanged.
+- Schema conversion must handle both `required` list representations (`[]string` and `[]interface{}`).
+
+## Phased Implementation Checklist
+
+### Phase 0: Release Baseline
+- [x] Create branch `codex/openai-skill-hardening`
+- [x] Bump version to `1.5.5`
+- [x] Add changelog entry for this hardening release
+
+### Phase 1: Functional Compatibility Fixes
+- [ ] Use `llmClient.GetSkills()` as the runtime source of tool definitions in TUI request paths.
+- [ ] Add batch tool-call message and execute all calls in sequence per assistant turn.
+- [ ] Append all tool results first, then send one continuation request to the LLM.
+- [ ] Preserve NSFW/provider gating semantics.
+
+### Phase 2: Validation and Error Hardening
+- [ ] Add skill schema validator for disk-loaded custom skills.
+- [ ] Reject invalid custom skill files during load with clear warnings.
+- [ ] Stop ignoring tool schema marshal failures in OpenAI/xAI backends; skip invalid tools with logging.
+- [ ] Convert tool argument parse failures into explicit tool-error messages.
+- [ ] Make Google schema conversion tolerant to `required` representation differences.
+
+### Test and Verification
+- [ ] Skills validation tests (valid + invalid custom skill files)
+- [ ] OpenAI tool conversion tests (success + skip-on-marshal-error)
+- [ ] xAI tool conversion tests (success + skip-on-marshal-error)
+- [ ] Google schema conversion tests (`required` parsing variants)
+- [ ] TUI multi-tool sequencing tests
+- [ ] Package test runs:
+  - `go test ./cmd/celeste/skills -v`
+  - `go test ./cmd/celeste/llm -v`
+  - `go test ./cmd/celeste/providers -v`
+  - `go test ./cmd/celeste/tui -v`
+
+## Acceptance Criteria
+1. Branch exists as `codex/openai-skill-hardening`.
+2. Version reports `1.5.5`.
+3. Non-NSFW chat sends tools when skills are enabled.
+4. All tool calls in a turn are executed and replied before continuation.
+5. Invalid custom skills are filtered and do not break model requests.
+6. xAI and Vertex paths remain functional and covered by regression tests.
+
+## Rollback Plan
+1. If provider regressions appear, rollback to previous tag (`1.5.4`) in production distribution.
+2. Temporarily disable Phase 2 validation gates (if needed) behind conservative fallback to preserve availability while debugging.
+3. Re-run provider-specific tests (`llm`, `providers`) before re-enabling.
+4. Publish a patch changelog entry documenting rollback cause and restored behavior.


### PR DESCRIPTION
## Summary
- Harden tool-calling compatibility paths across provider backends.
- Add validation for custom skill schemas and wire validation into skill registration.
- Add and expand test coverage for backend tool conversion, skill validation, and TUI tool call handling.

## Test plan
- [ ] Run `go test ./...`
- [ ] Verify tool-calling behavior manually in TUI flow
- [ ] Confirm CI workflow passes on this branch

Made with [Cursor](https://cursor.com)