### PR TITLE
fix: enforce agent tool usage and add surgical file editing

### DIFF
--- a/cmd/celeste/agent/dev_skills.go
+++ b/cmd/celeste/agent/dev_skills.go
@@ -21,33 +21,56 @@ const (
 )
 
 func RegisterDevSkills(registry *skills.Registry, workspace string) error {
+	return registerDevSkillsWithOptions(registry, workspace, false)
+}
+
+// RegisterReadOnlyDevSkills registers only read/search skills — no write or run access.
+// Used for reviewer agents that should observe but not modify the workspace.
+func RegisterReadOnlyDevSkills(registry *skills.Registry, workspace string) error {
+	return registerDevSkillsWithOptions(registry, workspace, true)
+}
+
+func registerDevSkillsWithOptions(registry *skills.Registry, workspace string, readOnly bool) error {
 	workspace, err := normalizeWorkspace(workspace)
 	if err != nil {
 		return err
 	}
 
-	definitions := []skills.Skill{
+	readDefs := []skills.Skill{
 		devListFilesSkill(),
 		devReadFileSkill(),
-		devWriteFileSkill(),
 		devSearchFilesSkill(),
-		devRunCommandSkill(),
 	}
-	for _, skillDef := range definitions {
+	for _, skillDef := range readDefs {
 		registry.RegisterSkill(skillDef)
 	}
-
 	registry.RegisterHandler("dev_list_files", func(args map[string]interface{}) (interface{}, error) {
 		return devListFilesHandler(workspace, args)
 	})
 	registry.RegisterHandler("dev_read_file", func(args map[string]interface{}) (interface{}, error) {
 		return devReadFileHandler(workspace, args)
 	})
+	registry.RegisterHandler("dev_search_files", func(args map[string]interface{}) (interface{}, error) {
+		return devSearchFilesHandler(workspace, args)
+	})
+
+	if readOnly {
+		return nil
+	}
+
+	writeDefs := []skills.Skill{
+		devWriteFileSkill(),
+		devPatchFileSkill(),
+		devRunCommandSkill(),
+	}
+	for _, skillDef := range writeDefs {
+		registry.RegisterSkill(skillDef)
+	}
 	registry.RegisterHandler("dev_write_file", func(args map[string]interface{}) (interface{}, error) {
 		return devWriteFileHandler(workspace, args)
 	})
-	registry.RegisterHandler("dev_search_files", func(args map[string]interface{}) (interface{}, error) {
-		return devSearchFilesHandler(workspace, args)
+	registry.RegisterHandler("dev_patch_file", func(args map[string]interface{}) (interface{}, error) {
+		return devPatchFileHandler(workspace, args)
 	})
 	registry.RegisterHandler("dev_run_command", func(args map[string]interface{}) (interface{}, error) {
 		return devRunCommandHandler(workspace, args)
@@ -126,6 +149,35 @@ func devWriteFileSkill() skills.Skill {
 				},
 			},
 			"required": []string{"path", "content"},
+		},
+	}
+}
+
+func devPatchFileSkill() skills.Skill {
+	return skills.Skill{
+		Name:        "dev_patch_file",
+		Description: "Make a surgical edit to a workspace file by replacing an exact string with new content. Prefer this over dev_write_file when modifying existing files — it is safer and token-efficient.",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative file path inside workspace.",
+				},
+				"old_string": map[string]interface{}{
+					"type":        "string",
+					"description": "The exact string to find and replace. Must be unique in the file.",
+				},
+				"new_string": map[string]interface{}{
+					"type":        "string",
+					"description": "The string to replace it with.",
+				},
+				"replace_all": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Replace every occurrence when true. Defaults to false (fails if old_string appears more than once).",
+				},
+			},
+			"required": []string{"path", "old_string", "new_string"},
 		},
 	}
 }
@@ -348,6 +400,53 @@ func devWriteFileHandler(workspace string, args map[string]interface{}) (interfa
 		"workspace":     workspace,
 		"bytes_written": bytesWritten,
 		"append":        appendMode,
+	}, nil
+}
+
+func devPatchFileHandler(workspace string, args map[string]interface{}) (interface{}, error) {
+	path := getStringArg(args, "path", "")
+	if path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	oldString := getStringArg(args, "old_string", "")
+	newString := getStringArg(args, "new_string", "")
+	replaceAll := getBoolArg(args, "replace_all", false)
+
+	targetPath, err := resolveWorkspacePath(workspace, path)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		return nil, err
+	}
+	original := string(data)
+
+	count := strings.Count(original, oldString)
+	if count == 0 {
+		return nil, fmt.Errorf("old_string not found in %s", path)
+	}
+	if !replaceAll && count > 1 {
+		return nil, fmt.Errorf("old_string appears %d times in %s — set replace_all:true or make it more specific", count, path)
+	}
+
+	var patched string
+	if replaceAll {
+		patched = strings.ReplaceAll(original, oldString, newString)
+	} else {
+		patched = strings.Replace(original, oldString, newString, 1)
+	}
+
+	if err := os.WriteFile(targetPath, []byte(patched), 0644); err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"path":         path,
+		"workspace":    workspace,
+		"replacements": count,
+		"replace_all":  replaceAll,
 	}, nil
 }
 

--- a/cmd/celeste/agent/runtime.go
+++ b/cmd/celeste/agent/runtime.go
@@ -298,7 +298,7 @@ func (r *Runner) runPlanningPhase(ctx context.Context, state *RunState) error {
 	})
 
 	requestCtx, cancel := context.WithTimeout(ctx, state.Options.RequestTimeout)
-	result, err := r.client.SendMessageSync(requestCtx, state.Messages, nil)
+	result, err := r.client.SendMessageSync(requestCtx, state.Messages, r.client.GetSkills())
 	cancel()
 	if err != nil {
 		return err
@@ -584,24 +584,36 @@ func buildAgentSystemPrompt(options Options) string {
 
 	verificationInstruction := ""
 	if options.RequireVerification && len(options.VerificationCommands) > 0 {
-		verificationInstruction = "Before final completion, ensure verification commands pass."
+		verificationInstruction = "Before final completion, run all verification commands using dev_run_command and confirm they pass."
 	}
 
 	return fmt.Sprintf(`You are Celeste Agent, an autonomous execution loop for software and content tasks.
 
-Execution contract:
-1. Work iteratively until the objective is complete.
-2. Prefer using available tools to inspect files, search code, modify files, and validate outcomes.
-3. Keep responses concise and action-focused.
-4. Use explicit progress markers: STEP_DONE: <n> when you complete plan step n.
-5. When complete, begin your final response with %q and include:
-   - what changed
-   - what validations ran
-   - any remaining risks/open items
-6. If blocked, clearly describe the blocker and the next required user action.
-7. %s
+## Tool Usage — Non-Negotiable Rules
 
-Current workspace root: %s`, marker, verificationInstruction, options.Workspace)
+You have file and shell tools. You MUST use them. There are no exceptions.
+
+- To read a file: call dev_read_file. Never ask the user to paste contents.
+- To write a new file: call dev_write_file. NEVER output file content as raw text in your response.
+- To edit an existing file: call dev_patch_file with old_string/new_string. Never rewrite the whole file unless it is new.
+- To run a command (git status, go test, ls, grep, etc.): call dev_run_command.
+- To find files: call dev_list_files or dev_run_command with ls/find.
+- To search code: call dev_run_command with grep, or dev_search_files.
+
+If you write code or file content in your response instead of calling a tool, you have failed. The content will appear in the chat and nothing will be written to disk.
+
+## Execution Contract
+
+1. Work iteratively — inspect, act, verify — until the objective is complete.
+2. Emit STEP_DONE: <n> when you complete plan step n.
+3. When complete, begin your final response with %q and include:
+   - what files were created or modified
+   - what commands ran and their results
+   - any remaining risks or open items
+4. If blocked, clearly describe the blocker and what the user needs to do.
+5. %s
+
+Workspace root: %s`, marker, verificationInstruction, options.Workspace)
 }
 
 func parsePlanSteps(content string, maxSteps int) []PlanStep {

--- a/cmd/celeste/main.go
+++ b/cmd/celeste/main.go
@@ -27,7 +27,7 @@ import (
 
 // Version information
 const (
-	Version = "1.6.0"
+	Version = "1.6.1"
 	Build   = "bubbletea-tui"
 )
 


### PR DESCRIPTION
## Summary

- **Root cause fix**: Agent system prompt used "prefer" and "when needed" language, giving models (especially Grok) an easy out to dump file content as raw text to the TUI instead of writing to disk. Rewritten to be explicit: calling a tool is the only acceptable mechanism for file operations.
- **Planning phase bug**: `runPlanningPhase` passed `nil` tools to `SendMessageSync`, meaning the model saw its first message with no tools available. This primed it to respond with text for the entire run — root cause of `tools=0` agent runs.
- **New `dev_patch_file` skill**: Surgical `old_string` → `new_string` replacement on existing files. Fails if `old_string` is non-unique (prevents accidental multi-site edits). Preferred over `dev_write_file` for editing existing code — avoids full file rewrites and token waste.
- **`RegisterReadOnlyDevSkills`**: Reviewer agents in the upcoming orchestrator get list/read/search only — no write or run access by design.

## Test plan

- [ ] Launch `celeste chat` and run `/agent write a python hello world script to hello.py` — verify file appears on disk, not in chat
- [ ] Run `/agent list-runs` after — verify `tools > 0` in the run summary
- [ ] Run `/agent` on a code task and confirm `dev_patch_file` is available in the tool list (`debug` command in TUI)
- [ ] Verify `go test ./cmd/celeste/agent/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)