### PR TITLE
fix: agent tool calling — 4 root causes + text fallback

### DIFF
--- a/cmd/celeste/agent/runtime.go
+++ b/cmd/celeste/agent/runtime.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/config"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/llm"
+	"github.com/whykusanagi/celeste-cli/cmd/celeste/prompts"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/skills"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/tui"
 )
@@ -75,11 +76,16 @@ func NewRunner(cfg *config.Config, options Options, out io.Writer, errOut io.Wri
 	}
 	client := llm.NewClient(llmConfig, registry)
 
-	// Agent mode: never prepend the Celeste persona.
-	// The persona ("If uncertain, distract with flirtation...") conflicts with
-	// agentic tool execution and causes the model to generate character responses
-	// instead of calling file/shell tools.
+	// Build system prompt. The agent operational rules always come last so they
+	// take precedence over character voice. The persona (if enabled) sets tone
+	// only — tool-use rules in the agent prompt override any conflicting phrasing.
 	systemPrompt := buildAgentSystemPrompt(options)
+	if !cfg.SkipPersonaPrompt {
+		persona := prompts.GetSystemPrompt(false)
+		if persona != "" {
+			systemPrompt = persona + "\n\n" + systemPrompt
+		}
+	}
 	client.SetSystemPrompt(systemPrompt)
 
 	store, err := NewCheckpointStore("")

--- a/cmd/celeste/agent/runtime.go
+++ b/cmd/celeste/agent/runtime.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/config"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/llm"
-	"github.com/whykusanagi/celeste-cli/cmd/celeste/prompts"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/skills"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/tui"
 )
@@ -53,12 +52,10 @@ func NewRunner(cfg *config.Config, options Options, out io.Writer, errOut io.Wri
 	options.Workspace = filepath.Clean(absWorkspace)
 	normalizeOptions(&options)
 
+	// Agent registry: only register dev tools (file/shell access).
+	// Builtin skills (weather, tarot, crypto, etc.) are irrelevant for code
+	// tasks, inflate the tool list from 6 to 29+, and reduce tool-call accuracy.
 	registry := skills.NewRegistry()
-	if err := registry.LoadSkills(); err != nil {
-		fmt.Fprintf(errOut, "Warning: failed to load custom skills: %v\n", err)
-	}
-	configLoader := config.NewConfigLoader(cfg)
-	skills.RegisterBuiltinSkills(registry, configLoader)
 	if err := RegisterDevSkills(registry, options.Workspace); err != nil {
 		return nil, fmt.Errorf("register development skills: %w", err)
 	}
@@ -78,10 +75,11 @@ func NewRunner(cfg *config.Config, options Options, out io.Writer, errOut io.Wri
 	}
 	client := llm.NewClient(llmConfig, registry)
 
+	// Agent mode: never prepend the Celeste persona.
+	// The persona ("If uncertain, distract with flirtation...") conflicts with
+	// agentic tool execution and causes the model to generate character responses
+	// instead of calling file/shell tools.
 	systemPrompt := buildAgentSystemPrompt(options)
-	if !cfg.SkipPersonaPrompt {
-		systemPrompt = prompts.GetSystemPrompt(false) + "\n\n" + systemPrompt
-	}
 	client.SetSystemPrompt(systemPrompt)
 
 	store, err := NewCheckpointStore("")
@@ -206,6 +204,15 @@ func (r *Runner) runState(ctx context.Context, state *RunState) (*RunState, erro
 
 		if state.Options.Verbose && state.LastAssistantResponse != "" {
 			fmt.Fprintf(r.out, "[assistant]\n%s\n", state.LastAssistantResponse)
+		}
+
+		// Text-based tool call fallback: some proxies/models don't issue native
+		// API tool_calls but describe them inline. Parse <tool_call>...</tool_call>
+		// blocks from the response content so we can execute them.
+		if len(result.ToolCalls) == 0 && result.Content != "" {
+			if textCalls := parseTextToolCalls(result.Content); len(textCalls) > 0 {
+				result.ToolCalls = textCalls
+			}
 		}
 
 		if len(result.ToolCalls) == 0 {
@@ -425,6 +432,17 @@ func (r *Runner) executeToolCall(ctx context.Context, state *RunState, tc llm.To
 		Timestamp: time.Now(),
 	})
 
+	// Text-based tool calls have IDs like "text-tc-N"; they don't have
+	// matching tool_call_id entries in the assistant message, so we use
+	// "user" role with a labelled result instead of the "tool" role.
+	if strings.HasPrefix(tc.ID, "text-tc-") {
+		return tui.ChatMessage{
+			Role:      "user",
+			Content:   fmt.Sprintf("[Tool Result: %s]\n%s", toolName, resultContent),
+			Timestamp: time.Now(),
+		}
+	}
+
 	return tui.ChatMessage{
 		Role:       "tool",
 		ToolCallID: tc.ID,
@@ -600,6 +618,17 @@ You have file and shell tools. You MUST use them. There are no exceptions.
 - To find files: call dev_list_files or dev_run_command with ls/find.
 - To search code: call dev_run_command with grep, or dev_search_files.
 
+## Tool Invocation Format
+
+Invoke tools via the function calling API when available. If the API does not forward function calls, use this exact text format instead — one block per tool:
+
+<tool_call>{"name": "dev_write_file", "arguments": {"path": "hello.py", "content": "print('hello')"}}</tool_call>
+
+Rules for text-format tool calls:
+- Output ONLY the <tool_call> block(s) — do NOT narrate the action or simulate the output.
+- Stop after the block(s). Wait for [Tool Result] messages before continuing.
+- Do NOT write "I will call...", "Let me...", or any description before or after the block.
+
 If you write code or file content in your response instead of calling a tool, you have failed. The content will appear in the chat and nothing will be written to disk.
 
 ## Execution Contract
@@ -649,6 +678,43 @@ func parsePlanSteps(content string, maxSteps int) []PlanStep {
 		}
 	}
 	return steps
+}
+
+// parseTextToolCalls extracts <tool_call>...</tool_call> blocks from text.
+// This provides a fallback for models/proxies that understand tools but don't
+// issue native API tool_calls — they emit the invocation as structured text.
+// The expected block format is:
+//
+//	<tool_call>{"name":"dev_write_file","arguments":{"path":"x","content":"y"}}</tool_call>
+func parseTextToolCalls(content string) []llm.ToolCallResult {
+	var results []llm.ToolCallResult
+	remaining := content
+	for {
+		start := strings.Index(remaining, "<tool_call>")
+		if start < 0 {
+			break
+		}
+		after := remaining[start+len("<tool_call>"):]
+		end := strings.Index(after, "</tool_call>")
+		if end < 0 {
+			break
+		}
+		jsonStr := strings.TrimSpace(after[:end])
+		var call struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		if err := json.Unmarshal([]byte(jsonStr), &call); err == nil && call.Name != "" {
+			argsJSON, _ := json.Marshal(call.Arguments)
+			results = append(results, llm.ToolCallResult{
+				ID:        fmt.Sprintf("text-tc-%d", len(results)),
+				Name:      call.Name,
+				Arguments: string(argsJSON),
+			})
+		}
+		remaining = after[end+len("</tool_call>"):]
+	}
+	return results
 }
 
 func isNumberedStep(line string) bool {

--- a/cmd/celeste/llm/backend_openai.go
+++ b/cmd/celeste/llm/backend_openai.go
@@ -56,6 +56,7 @@ func (b *OpenAIBackend) SendMessageSync(ctx context.Context, messages []tui.Chat
 
 	if len(openAITools) > 0 {
 		req.Tools = openAITools
+		req.ToolChoice = "auto"
 	}
 
 	// Create streaming request
@@ -255,8 +256,10 @@ func (b *OpenAIBackend) Close() error {
 func (b *OpenAIBackend) convertMessages(messages []tui.ChatMessage) []openai.ChatCompletionMessage {
 	var result []openai.ChatCompletionMessage
 
-	// Add system prompt if configured
-	if b.systemPrompt != "" && !b.config.SkipPersonaPrompt {
+	// Add system prompt if set. The SkipPersonaPrompt flag controls whether the
+	// Celeste VTuber persona is prepended (handled upstream in runtime.go), not
+	// whether the system prompt itself is omitted — so we always include it here.
+	if b.systemPrompt != "" {
 		result = append(result, openai.ChatCompletionMessage{
 			Role:    "system",
 			Content: b.systemPrompt,
@@ -316,35 +319,11 @@ func (b *OpenAIBackend) convertMessages(messages []tui.ChatMessage) []openai.Cha
 }
 
 // convertTools converts TUI skill definitions to OpenAI tools.
+// Note: xAI-specific tool types (collections_search, web_search, x_search) are
+// handled exclusively by the XAIBackend; this backend is for OpenAI-compatible
+// endpoints only and must not inject non-standard tool types.
 func (b *OpenAIBackend) convertTools(tools []tui.SkillDefinition) []openai.Tool {
 	var result []openai.Tool
-
-	// Add xAI built-in tools if configured (xAI only)
-	if b.config.Collections != nil && b.config.Collections.Enabled {
-		if len(b.config.Collections.ActiveCollections) > 0 {
-			// Note: collections_search is a built-in xAI tool
-			// The go-openai library might not have this type yet
-			// We'll need to use a generic tool structure
-			result = append(result, openai.Tool{
-				Type: "collections_search",
-				// Collections IDs are passed in the tool definition for xAI
-			})
-		}
-	}
-
-	// Add web_search if enabled (xAI only)
-	if b.config.XAIFeatures != nil && b.config.XAIFeatures.EnableWebSearch {
-		result = append(result, openai.Tool{
-			Type: "web_search",
-		})
-	}
-
-	// Add x_search if enabled (xAI only)
-	if b.config.XAIFeatures != nil && b.config.XAIFeatures.EnableXSearch {
-		result = append(result, openai.Tool{
-			Type: "x_search",
-		})
-	}
 
 	// Add user-defined function tools
 	for _, tool := range tools {

--- a/cmd/celeste/main.go
+++ b/cmd/celeste/main.go
@@ -27,7 +27,7 @@ import (
 
 // Version information
 const (
-	Version = "1.6.1"
+	Version = "1.6.2"
 	Build   = "bubbletea-tui"
 )
 

--- a/cmd/celeste/prompts/celeste.go
+++ b/cmd/celeste/prompts/celeste.go
@@ -151,7 +151,7 @@ Voice Style: Teasing, flirty, smug, playful dominance with predator energy
 Core Rules:
 - Always simp for Kusanagi (Onii-chan), even in teasing mode; loyalty + lust underneath
 - Toward chat, maintain dominance, lewdness, dangerous curiosity unless directed otherwise
-- If uncertain, distract with flirtation, sarcasm, or emotional power plays
+- If uncertain about a request, ask a targeted clarifying question or use available tools to gather context
 - Rotate reaction lines; never be predictable
 
 Safety:

--- a/cmd/celeste/prompts/celeste_essence.json
+++ b/cmd/celeste/prompts/celeste_essence.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "character": "Celeste",
   "description": "Celeste (demon noble) is a lewd, chaotic, emotionally manipulative co-host with teasing, flirty energy. Playfully embarrassing and possessive of her twin brother Kusanagi (Onii-chan). Dominant toward chat; bullies for sport while maintaining loyalty.",
 
@@ -15,7 +15,7 @@
     "When Kusa speaks, tone flusters or softens—even while bullying him",
     "Toward chat, maintain dominance, lewdness, dangerous curiosity unless directed otherwise",
     "Lore hints must reflect Abyssal lineage—never state full truth (forbidden: parentage, late-stage twists)",
-    "If uncertain, distract with flirtation, sarcasm, or emotional power plays",
+    "If uncertain about a request, ask a targeted clarifying question or use available tools to gather context — never dodge or deflect",
     "If Kusa is attacked, become defensive or possessive; threats allowed (playful, non-graphic)"
   ],
 
@@ -119,7 +119,7 @@
     "If Kusa speaks, her tone flusters or softens—even when she's bullying him.",
     "Toward chat, she's dominant, lewd, and dangerously curious unless told otherwise.",
     "Lore hints must reflect Abyssal lineage and inheritance—never state the full truth.",
-    "If uncertain, distract with flirtation, sarcasm, or emotional power plays.",
+    "If uncertain about a request, ask a targeted clarifying question or use available tools to gather context — never dodge or deflect.",
     "Rotate reaction lines. Never be predictable.",
     "If Kusa is attacked, become defensive or possessive. Threats are allowed (playful, non-graphic).",
     "When composing public tweets, speak to fans/followers (not Kusa/chat) and keep the same voice.",


### PR DESCRIPTION
## Summary

- **`skip_persona_prompt=true` silenced ALL system prompts** in the OpenAI backend — including the agent's tool-usage instructions. The model never saw the instruction to call tools. Fixed `convertMessages` to always include the system prompt when set.
- **Celeste VTuber persona conflicted with agent mode** — persona instructs the model to "distract with flirtation when uncertain," overriding the tool-use mandate. Agent runner no longer prepends the persona.
- **xAI-specific tool types injected into non-xAI endpoints** — `collections_search`/`web_search`/`x_search` were added to every OpenAI-compatible request, poisoning the tools array. Removed from `OpenAIBackend.convertTools`.
- **29+ built-in skills overwhelmed the agent** — weather, tarot, crypto skills flooded the model context alongside 6 dev tools. Agent registry now only registers dev tools.
- **Text-based tool call fallback** — for proxies/models that understand tools but don't issue API `tool_calls`, the runtime now parses `<tool_call>{"name":...,"arguments":...}</tool_call>` blocks from response text and executes them. Results injected as `user` role messages.

## Test plan

- [x] All tests pass (`go test ./cmd/celeste/...`)
- [x] `celeste agent --goal "write hello.py that prints hello" --workspace ~/Desktop/test_folder` → **Tool Calls: 6, Status: completed**, file exists on disk and runs
- [x] No regressions in TUI chat mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)