### PR TITLE
fix: block sudo/su + OS/env detection in agent system prompt

### DIFF
--- a/cmd/celeste/agent/dev_skills.go
+++ b/cmd/celeste/agent/dev_skills.go
@@ -537,6 +537,9 @@ func devRunCommandHandler(workspace string, args map[string]interface{}) (interf
 	if strings.TrimSpace(command) == "" {
 		return nil, fmt.Errorf("command is required")
 	}
+	if fields := strings.Fields(command); len(fields) > 0 && (fields[0] == "sudo" || fields[0] == "su") {
+		return nil, fmt.Errorf("sudo/su is not permitted in dev_run_command; run commands as the current user only")
+	}
 	timeoutSeconds := getIntArg(args, "timeout_seconds", 20)
 	if timeoutSeconds <= 0 {
 		timeoutSeconds = 20

--- a/cmd/celeste/agent/dev_skills_test.go
+++ b/cmd/celeste/agent/dev_skills_test.go
@@ -88,3 +88,36 @@ func TestDevRunCommandExecutesInWorkspace(t *testing.T) {
 	_, statErr := os.Stat(filepath.Join(workspace, ".."))
 	assert.NoError(t, statErr)
 }
+
+func TestDevRunCommandBlocksSudo(t *testing.T) {
+	workspace := t.TempDir()
+	registry := skills.NewRegistry()
+	require.NoError(t, RegisterDevSkills(registry, workspace))
+
+	blocked := []string{
+		"sudo apt-get install python3",
+		"sudo rm -rf /",
+		"su - root",
+		"su root",
+		"sudo",
+	}
+	for _, cmd := range blocked {
+		_, err := registry.Execute("dev_run_command", map[string]interface{}{"command": cmd})
+		require.Error(t, err, "expected block for: %s", cmd)
+		assert.Contains(t, err.Error(), "sudo/su is not permitted", "wrong error for: %s", cmd)
+	}
+
+	// Commands that merely mention sudo should not be blocked.
+	allowed := []string{
+		"grep sudo /etc/sudoers",
+		"echo 'sudo is useful'",
+		"cat /etc/sudoers",
+	}
+	for _, cmd := range allowed {
+		_, err := registry.Execute("dev_run_command", map[string]interface{}{"command": cmd})
+		// These may fail for other reasons (file missing) but not the sudo block.
+		if err != nil {
+			assert.NotContains(t, err.Error(), "sudo/su is not permitted", "false-positive block for: %s", cmd)
+		}
+	}
+}

--- a/cmd/celeste/agent/runtime.go
+++ b/cmd/celeste/agent/runtime.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -79,7 +80,8 @@ func NewRunner(cfg *config.Config, options Options, out io.Writer, errOut io.Wri
 	// Build system prompt. The agent operational rules always come last so they
 	// take precedence over character voice. The persona (if enabled) sets tone
 	// only — tool-use rules in the agent prompt override any conflicting phrasing.
-	systemPrompt := buildAgentSystemPrompt(options)
+	envContext := detectEnvContext()
+	systemPrompt := buildAgentSystemPrompt(options, envContext)
 	if !cfg.SkipPersonaPrompt {
 		persona := prompts.GetSystemPrompt(false)
 		if persona != "" {
@@ -600,7 +602,41 @@ func buildVerificationFailurePrompt(checks []VerificationCheck, options Options)
 	return fmt.Sprintf("Verification failed. Fix the issues and continue execution. Re-run validations before completion.\n\nFailed checks:\n%s\n\nWhen complete, respond with '%s'.", strings.Join(failed, "\n"), options.CompletionMarker)
 }
 
-func buildAgentSystemPrompt(options Options) string {
+// detectEnvContext probes the runtime environment and returns a concise
+// summary string for inclusion in the agent system prompt.
+func detectEnvContext() string {
+	osName := runtime.GOOS
+	if osName == "darwin" {
+		osName = "macOS"
+	}
+	arch := runtime.GOARCH
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "unknown"
+	}
+
+	pkgManager := "none"
+	for _, candidate := range []string{"brew", "apt-get", "apt", "dnf", "yum", "pacman", "apk", "scoop", "choco"} {
+		if path, err := exec.LookPath(candidate); err == nil {
+			pkgManager = filepath.Base(path)
+			break
+		}
+	}
+
+	pythonExe := "none"
+	for _, candidate := range []string{"python3", "python"} {
+		if _, err := exec.LookPath(candidate); err == nil {
+			pythonExe = candidate
+			break
+		}
+	}
+
+	return fmt.Sprintf("OS: %s (%s)\nShell: %s\nPackage manager: %s\nPython: %s",
+		osName, arch, shell, pkgManager, pythonExe)
+}
+
+func buildAgentSystemPrompt(options Options, envContext string) string {
 	marker := options.CompletionMarker
 	if marker == "" {
 		marker = "TASK_COMPLETE:"
@@ -648,7 +684,13 @@ If you write code or file content in your response instead of calling a tool, yo
 4. If blocked, clearly describe the blocker and what the user needs to do.
 5. %s
 
-Workspace root: %s`, marker, verificationInstruction, options.Workspace)
+## Environment
+
+%s
+
+Use the package manager and Python executable listed above. Do not use sudo or assume alternatives are available.
+
+Workspace root: %s`, marker, verificationInstruction, envContext, options.Workspace)
 }
 
 func parsePlanSteps(content string, maxSteps int) []PlanStep {

--- a/cmd/celeste/agent/runtime_phase_test.go
+++ b/cmd/celeste/agent/runtime_phase_test.go
@@ -76,3 +76,21 @@ func TestRunVerificationPhaseFailureReturnsToExecution(t *testing.T) {
 	assert.Equal(t, "user", last.Role)
 	assert.Contains(t, last.Content, "Verification failed")
 }
+
+func TestDetectEnvContext(t *testing.T) {
+	env := detectEnvContext()
+	assert.Contains(t, env, "OS:")
+	assert.Contains(t, env, "Shell:")
+	assert.Contains(t, env, "Package manager:")
+	assert.Contains(t, env, "Python:")
+}
+
+func TestBuildAgentSystemPromptContainsEnvSection(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Workspace = t.TempDir()
+	prompt := buildAgentSystemPrompt(opts, "OS: linux (amd64)\nShell: /bin/bash\nPackage manager: apt-get\nPython: python3")
+	assert.Contains(t, prompt, "## Environment")
+	assert.Contains(t, prompt, "apt-get")
+	assert.Contains(t, prompt, "python3")
+	assert.Contains(t, prompt, opts.Workspace)
+}

--- a/cmd/celeste/llm/backend_xai.go
+++ b/cmd/celeste/llm/backend_xai.go
@@ -280,9 +280,7 @@ func (b *XAIBackend) SendMessageStream(ctx context.Context, messages []tui.ChatM
 func (b *XAIBackend) SendMessageSync(ctx context.Context, messages []tui.ChatMessage, tools []tui.SkillDefinition) (*ChatCompletionResult, error) {
 	var content strings.Builder
 	var result *ChatCompletionResult
-	var streamErr error
-
-	streamErr = b.SendMessageStream(ctx, messages, tools, func(chunk StreamChunk) {
+	streamErr := b.SendMessageStream(ctx, messages, tools, func(chunk StreamChunk) {
 		if chunk.Content != "" {
 			content.WriteString(chunk.Content)
 		}

--- a/cmd/celeste/main.go
+++ b/cmd/celeste/main.go
@@ -27,7 +27,7 @@ import (
 
 // Version information
 const (
-	Version = "1.6.2"
+	Version = "1.6.3"
 	Build   = "bubbletea-tui"
 )
 


### PR DESCRIPTION
## Summary

- **Block `sudo`/`su` in `dev_run_command`** — rejects any command whose first token is `sudo` or `su` before execution, with a clear error message so the model doesn't retry. The agent that ran `sudo apt-get install python3` last session would have had this blocked instantly instead of hanging on a password prompt.
- **OS/environment detection injected into agent system prompt** — `detectEnvContext()` probes `runtime.GOOS/ARCH`, `$SHELL`, and `exec.LookPath` for available package managers and python. On macOS arm64 this produces `brew` + `python3` which gets embedded in a `## Environment` section so the model uses the right tools on the first attempt.

Example of what the model now sees:
```
## Environment

OS: macOS (arm64)
Shell: /bin/zsh
Package manager: brew
Python: python3

Use the package manager and Python executable listed above. Do not use sudo or assume alternatives are available.
```

## Test plan

- [x] All tests pass (`go test ./cmd/celeste/...`)
- [x] `TestDevRunCommandBlocksSudo` — blocked: `sudo apt-get`, `sudo rm -rf /`, `su - root`; allowed: `grep sudo /etc/sudoers`
- [x] `TestDetectEnvContext` — all four fields present
- [x] `TestBuildAgentSystemPromptContainsEnvSection` — env section in prompt output

🤖 Generated with [Claude Code](https://claude.com/claude-code)