### PR TITLE
fix(codegraph): splitCamelCase requires 3+ uppercase for acronyms (v1.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-04-13
+
+### Fixed
+
+- **`splitCamelCase` end-of-acronym rule now requires 3+ consecutive uppercase letters.** Two
+  uppercase letters followed by a lowercase word is a PascalCase boundary, not an acronym edge.
+  Previously, `JQueryStatic` decomposed into `["J", "Query", "Static"]`, which caused the
+  `jQueryStatic` pollution problem documented in
+  [celeste-stopwords Issue #1](https://github.com/whykusanagi/celeste-stopwords/blob/main/docs/KNOWN_QUALITY_ISSUES.md):
+  searches for "query" would match `JQueryStatic` via the stray `query` token, and ~1,650 other
+  identifiers exhibited the same bug across a 31-repo training corpus. `HTTPServer`,
+  `HTMLToMarkdown`, `CSVParser`, and every other 3+ consecutive-uppercase acronym still splits
+  correctly.
+
+  Affected identifier families now atomize correctly:
+  - `JQuery` / `JQueryStatic` / `JQueryElement` / `JQueryPromise`
+  - `IFoo` / `IArguments` / `IPromise` / `ICache` / any `I`-prefixed TypeScript interface
+  - `IPv4` / `IPv6` / `VNode` / `ETag` / `OAuth2` / `XDist`
+
+### Changed
+
+- **MinHash signatures computed by previous versions are now semantically stale.** Any codegraph
+  index built with celeste-cli < 1.9.0 carries MinHashes derived from the old `splitCamelCase`
+  tokenization. Existing indexes continue to work — symbol lookups, edges, and keyword search
+  are unaffected — but semantic search accuracy improves if you rebuild:
+
+  ```bash
+  celeste index --rebuild
+  ```
+
+  A future release will add automatic detection of stale indexes and surface a rebuild prompt.
+
+### Details
+
+- Only `cmd/celeste/codegraph/shingle.go:splitCamelCase` changed. The fix adds one more
+  `unicode.IsUpper(runes[i-3])` check and raises the loop guard from `i > 1` to `i > 2`.
+- All existing `TestSplitIdentifier` cases still pass (no regressions on `validateSession`,
+  `HTTPServer`, `parseJSON`, `XMLParser`, `HTMLToMarkdown`, `get_user_by_id`, `ID`, `x`).
+- 12 new anchor cases added in `shingle_test.go` for the fixed identifier families.
+- See `celeste-stopwords/results/simulation_report.md` for the empirical analysis: 3,249
+  symbols in a 1.6M-symbol training corpus have name re-splits under the fix.
+
 ## [1.8.0] - 2026-04-03
 
 ### Added

--- a/cmd/celeste/codegraph/shingle.go
+++ b/cmd/celeste/codegraph/shingle.go
@@ -58,9 +58,28 @@ func splitIdentifier(name string) []string {
 }
 
 // splitCamelCase splits a camelCase or PascalCase string into words.
-// "HTTPServer" -> ["HTTP", "Server"]
-// "parseJSON" -> ["parse", "JSON"]
+//
+// "HTTPServer"     -> ["HTTP", "Server"]
+// "parseJSON"      -> ["parse", "JSON"]
 // "HTMLToMarkdown" -> ["HTML", "To", "Markdown"]
+// "JQueryStatic"   -> ["JQuery", "Static"]     // fixed — see below
+// "IFoo"           -> ["IFoo"]                 // fixed
+// "IPv4"           -> ["IPv4"]                 // fixed
+// "OAuth2"         -> ["OAuth2"]               // fixed
+//
+// The "end of acronym" rule requires THREE consecutive uppercase letters
+// before a lowercase boundary — not two. Previously, any Upper-Upper-lower
+// triple fired the rule, which split PascalCase identifiers like JQuery
+// and IFoo into single-letter first tokens ["J", "Query"] / ["I", "Foo"].
+// That decomposition caused the jQueryStatic pollution problem documented
+// in celeste-stopwords Issue #1: searches for "query" would match
+// JQueryStatic via the stray "query" token, and ~1,650 other identifiers
+// exhibited the same bug across a 31-repo training corpus.
+//
+// Requiring 3+ uppercase letters treats HTTP/HTML/CSV/XML as acronyms
+// (correct split) while treating JQ/IF/IP/OA/VN/XD as PascalCase word
+// starts (no acronym split). See celeste-stopwords commit 5f0ea41 for
+// the simulation evidence.
 func splitCamelCase(s string) []string {
 	if s == "" {
 		return nil
@@ -78,9 +97,12 @@ func splitCamelCase(s string) []string {
 			continue
 		}
 
-		// Transition: Upper -> Upper -> lower marks end of acronym
-		// "HTTPServer" at position of 'e' (after 'S'): "HTTP" + "Server"
-		if i > 1 && unicode.IsUpper(runes[i-1]) && unicode.IsUpper(runes[i-2]) && unicode.IsLower(runes[i]) {
+		// Transition: Upper -> Upper -> Upper -> lower marks end of acronym.
+		// Requires 3+ consecutive uppers; two caps followed by lower is a
+		// PascalCase word boundary (JQuery, IFoo), not an acronym edge.
+		// "HTTPServer" at i=5 ('e'): runes[2..4] = T,T,P all upper → emit "HTTP".
+		// "JQueryStatic" at i=2 ('u'): only J,Q upper, fails the i>2 gate → skip.
+		if i > 2 && unicode.IsUpper(runes[i-1]) && unicode.IsUpper(runes[i-2]) && unicode.IsUpper(runes[i-3]) && unicode.IsLower(runes[i]) {
 			words = append(words, string(runes[start:i-1]))
 			start = i - 1
 			continue

--- a/cmd/celeste/codegraph/shingle_test.go
+++ b/cmd/celeste/codegraph/shingle_test.go
@@ -12,6 +12,7 @@ func TestSplitIdentifier(t *testing.T) {
 		input    string
 		expected []string
 	}{
+		// Unchanged behavior — acronyms of 3+ uppers still split correctly.
 		{"validateSession", []string{"validate", "session"}},
 		{"HTTPServer", []string{"http", "server"}},
 		{"get_user_by_id", []string{"get", "user", "by", "id"}},
@@ -20,6 +21,25 @@ func TestSplitIdentifier(t *testing.T) {
 		{"ID", []string{"id"}},
 		{"x", []string{"x"}},
 		{"HTMLToMarkdown", []string{"html", "to", "markdown"}},
+
+		// Fixed behavior — PascalCase identifiers with a 2-uppercase prefix
+		// followed by a lowercase word are NO LONGER split at the first letter.
+		// These all used to produce single-letter first tokens like ["j", "query"]
+		// or ["i", "foo"], which caused the SPEC §8.2 Issue #1 jQueryStatic
+		// pollution across ~1,650 identifiers in the celeste-stopwords training
+		// corpus (kubernetes, TypeScript, microsoft/playwright, airflow, etc).
+		{"JQuery", []string{"jquery"}},
+		{"JQueryStatic", []string{"jquery", "static"}},
+		{"JQueryElement", []string{"jquery", "element"}},
+		{"IFoo", []string{"ifoo"}},
+		{"IArguments", []string{"iarguments"}},
+		{"IPromise", []string{"ipromise"}},
+		{"IPv4", []string{"ipv4"}},
+		{"IPv6", []string{"ipv6"}},
+		{"OAuth2", []string{"oauth2"}},
+		{"ETag", []string{"etag"}},
+		{"VNode", []string{"vnode"}},
+		{"XDist", []string{"xdist"}},
 	}
 
 	for _, tt := range tests {

--- a/cmd/celeste/main.go
+++ b/cmd/celeste/main.go
@@ -45,7 +45,7 @@ import (
 // CI/CD sets these: go build -ldflags "-X main.Version=1.8.0 -X main.Build=bubbletea-tui -X main.CommitSHA=abc123"
 // When not set by ldflags, defaults are used.
 var (
-	Version   = "1.8.4"
+	Version   = "1.9.0"
 	Build     = "bubbletea-tui"
 	CommitSHA = "dev"
 )


### PR DESCRIPTION
## Summary

Fixes a ~1,650-identifier class of shingle pollution in `splitCamelCase`, the canonical motivating example being `JQueryStatic` decomposing into `["J", "Query", "Static"]` and matching unrelated searches for "query". Bumps to **v1.9.0** because MinHash signatures computed by previous versions are semantically stale (existing indexes keep working, but semantic search accuracy improves on rebuild).

## The bug

`splitCamelCase` used an "end of acronym" rule that fired on any `Upper-Upper-lower` triple, emitting the first letter as a standalone token:

| Input | Old split | New split |
|---|---|---|
| `JQueryStatic` | `[J, Query, Static]` | `[JQuery, Static]` |
| `IFoo` | `[I, Foo]` | `[IFoo]` |
| `IPv4` | `[I, Pv4]` | `[IPv4]` |
| `IPv6` | `[I, Pv6]` | `[IPv6]` |
| `OAuth2` | `[O, Auth2]` | `[OAuth2]` |
| `ETag` | `[E, Tag]` | `[ETag]` |
| `VNode` | `[V, Node]` | `[VNode]` |
| `XDist` | `[X, Dist]` | `[XDist]` |

The stray `J`/`I`/`O`/`E`/`V`/`X` tokens are cheap noise that MinHash drops quickly, but the FRAGMENTS left behind (`query`, `foo`, `auth2`, `tag`, `node`) were polluting unrelated semantic searches. `celeste-stopwords` mined 1,619,235 symbols across 31 OSS repos (`kubernetes`, `microsoft/TypeScript`, `airflow`, `next.js`, `grafana`, etc.) and found **3,249 symbols (~1,650 unique forms)** exhibiting this bug. Distribution by first letter:

```
i: 677  o: 173  p: 157  t: 152  x: 144  a: 131  m: 120  c: 107
```

The top-10 most frequent polluters in our corpus:

```
28 × oauth2flowhandler       (home-assistant)
24 × ifoo                    (microsoft/TypeScript)
15 × iarguments              (denoland/deno, microsoft/TypeScript, swc-project/swc)
15 × ipromise                (microsoft/TypeScript)
 9 × xdist                   (microsoft/TypeScript, swc-project/swc)
 8 × ipv4                    (istio, moby)
 8 × alambda                 (microsoft/TypeScript, swc-project/swc)
 7 × jquery                  (go-gitea, microsoft/TypeScript)
 7 × ipv6                    (istio, moby)
 6 × etag                    (astral-sh/uv, backstage, rclone)
```

## The fix

One semantic change in `shingle.go:splitCamelCase`: **require 3+ consecutive uppercase letters** before the end-of-acronym rule fires. Two caps + lower is a PascalCase boundary (`JQuery`, `IFoo`), not an acronym edge.

```diff
-if i > 1 && unicode.IsUpper(runes[i-1]) && unicode.IsUpper(runes[i-2]) && unicode.IsLower(runes[i]) {
+if i > 2 && unicode.IsUpper(runes[i-1]) && unicode.IsUpper(runes[i-2]) && unicode.IsUpper(runes[i-3]) && unicode.IsLower(runes[i]) {
```

`HTTPServer`, `HTMLToMarkdown`, `CSVParser`, `XMLParser`, and every other 3+-uppercase acronym continues to split correctly.

## Test plan

- [x] `TestSplitIdentifier` passes on all 8 existing cases (no regressions):
  - `validateSession`, `HTTPServer`, `get_user_by_id`, `parseJSON`, `XMLParser`, `ID`, `x`, `HTMLToMarkdown`
- [x] 12 new anchor cases added and passing:
  - `JQuery`, `JQueryStatic`, `JQueryElement`, `IFoo`, `IArguments`, `IPromise`, `IPv4`, `IPv6`, `OAuth2`, `ETag`, `VNode`, `XDist`
- [x] Full `go test ./cmd/celeste/codegraph/...` passes
- [x] `go vet` clean, `gofmt -l` clean
- [x] `go build ./...` succeeds
- [x] `cmd/celeste/main.go:Version` bumped to `1.9.0`
- [x] `CHANGELOG.md` has `[1.9.0] - 2026-04-13` entry with rebuild instructions

## MinHash invalidation

**Existing celeste indexes carry stale MinHash signatures** because symbol tokenization changes. Symbol/edge/keyword queries are unaffected; semantic search accuracy improves on rebuild:

```bash
celeste index --rebuild
```

The CHANGELOG calls this out prominently. A follow-up should add automatic stale-index detection (via a `meta.shingle_version` row in the codegraph SQLite store).

## Empirical analysis

Full simulation report from celeste-stopwords:
- `pipeline/cmd/simulate/main.go` — the Jaccard simulator that scored 1,619,235 symbols with `-fix-split` mode
- `results/simulation_report.md` — per-query diffs, the 3,249 re-split count, and the detailed reasoning for why the fix addresses the root cause of SPEC §8.2 Issue #1

## Follow-ups (not in this PR)

- Automatic stale-index detection on open (warn the user to `--rebuild`)
- Digit→upper boundary detection (currently `OAuth2FlowHandler` becomes `[OAuth2Flow, Handler]` instead of `[OAuth2, Flow, Handler]` — minor edge case)
- celeste-stopwords v1.1.0 artifact regenerated against the fixed tokenization

🤖 Generated with [Claude Code](https://claude.com/claude-code)