### PR TITLE
fix(release): bump Go 1.26.2 + pin CGO_ENABLED=0 for v1.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,24 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26.1'
+        go-version: '1.26.2'
 
     - name: Get version from tag
       id: get_version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
     - name: Build binaries
+      env:
+        # v1.9.0 introduces a CGo tree-sitter TypeScript parser behind a
+        # //go:build cgo constraint. Release binaries are built pure-Go
+        # (CGO_ENABLED=0) so every platform in the release matrix gets
+        # the same fully-static artifact and the parser_ts_stub.go
+        # fallback. Users who want the tree-sitter improvement can
+        # build from source with CGo enabled. The v2.1.0 release
+        # workflow will replace this with a zig-cc cross-toolchain or
+        # a native-runner matrix so the tree-sitter parser ships with
+        # pre-built binaries too.
+        CGO_ENABLED: "0"
       run: |
         # Linux
         GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${{ steps.get_version.outputs.VERSION }} -X main.CommitSHA=${{ github.sha }}" -o dist/celeste-linux-amd64 ./cmd/celeste
@@ -62,7 +73,7 @@ jobs:
           --version "${{ steps.get_version.outputs.VERSION }}" \
           --commit "${{ github.sha }}" \
           --tag "v${{ steps.get_version.outputs.VERSION }}" \
-          --go-version "1.26.1" \
+          --go-version "1.26.2" \
           --dist-dir dist \
           --output dist/manifest.json
 


### PR DESCRIPTION
## Summary

Release workflow hardening before tagging v1.9.0. Two pre-existing issues in `release.yml` that would have broken the tag build as-is:

1. **Go 1.26.1 stdlib CVEs.** Same 5 CVEs that took out the CI Security Scan on PR #16 (crypto/x509 × 3, crypto/tls, html/template). Fixed in 1.26.2. The release workflow was pinned to 1.26.1 in two places: \`setup-go\` action and the manifest metadata. Bumped both.

2. **CGo mixing on cross-builds.** v1.9.0 added the tree-sitter TS parser under \`//go:build cgo\` with a pure-Go stub under \`//go:build !cgo\`. Without an explicit setting, \`GOOS=linux GOARCH=amd64\` would build native on ubuntu-latest with CGo on (non-portable libc/libstdc++ deps), while every cross-build would silently fall back to the stub. Pinned \`CGO_ENABLED=0\` at the build step so every platform in the release matrix ships fully-static pure-Go binaries using the stub path.

Trade-off: released binaries use the regex-based TS parser (v1.8.x behavior), not the tree-sitter improvement. Users who want the full v1.9.0 experience can \`go build\` from source with CGo enabled — the build constraints switch to the tree-sitter file automatically. A proper multi-platform CGo release (zig-cc cross-toolchain or native-runner matrix) is queued for v2.1.0.

## Validation

- \`govulncheck ./...\` on Go 1.26.2 → "No vulnerabilities found"
- \`CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./cmd/celeste\` → exit 0
- \`CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./cmd/celeste\` → exit 0
- \`CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/celeste\` → exit 0

## Test plan

- [ ] PR CI runs green (Test matrix / Lint / Security Scan / Docker / Build)
- [ ] Merge, then tag v1.9.0, then watch the Release workflow produce signed cross-platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)