### PR TITLE
fix(tui): streaming tick-complete race truncated short first chunks (v1.9.1)

### DIFF
--- a/cmd/celeste/tui/app.go
+++ b/cmd/celeste/tui/app.go
@@ -62,6 +62,26 @@ type AppModel struct {
 	typingPos     int    // Current position in content
 	animFrame     int    // Animation frame counter
 
+	// streamDone is true once StreamDoneMsg has been received for the
+	// currently-rendering assistant message. It coordinates the typing
+	// animation with the network stream:
+	//
+	//   - While streamDone == false, the TickMsg handler MUST keep the
+	//     ticker alive even after typingPos catches up to len(typingContent),
+	//     because more chunks may still be arriving and extending the buffer.
+	//   - Once streamDone == true, the TickMsg tick-complete branch can
+	//     safely commit the final content to session history and stop.
+	//
+	// Without this coordination, a short first chunk (1-3 chars) drained
+	// the typing animation before the second chunk arrived, committed that
+	// single character to session persistence as the "complete" assistant
+	// reply, and left every subsequent chunk to pile up in a zombie buffer
+	// with no active ticker to render it. The session and the next LLM
+	// request would both see content_len=1 — the "O" truncation bug.
+	// See log /Users/kusanagi/.celeste/logs/celeste_2026-04-13.log for a
+	// captured reproduction.
+	streamDone bool
+
 	// Pending tool call tracking
 	pendingToolCallID  string // Track tool call ID for sending result back to LLM
 	pendingToolCalls   []pendingToolCall
@@ -1268,18 +1288,26 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case StreamChunkMsg:
 		if msg.Chunk.IsFirst {
-			// First chunk: start the assistant message and typing animation
+			// First chunk: start the assistant message and typing animation.
+			// Reset streamDone here — the tick handler uses it to decide
+			// whether to commit when typing catches up.
 			m.chat = m.chat.AddAssistantMessage("")
 			m.typingContent = msg.Chunk.Content
 			m.typingPos = 0
 			m.streaming = true
+			m.streamDone = false
 			m.status = m.status.SetStreaming(true)
 			m.status = m.status.SetText(StreamingSpinner(m.animFrame) + " " + ThinkingAnimation(m.animFrame))
 			cmds = append(cmds, tea.Tick(typingTickInterval, func(t time.Time) tea.Msg {
 				return TickMsg{Time: t}
 			}))
 		} else {
-			// Subsequent chunks: extend the typing buffer
+			// Subsequent chunks: extend the typing buffer. The running
+			// ticker will pick up the extension on its next fire. If the
+			// ticker happened to die right before this chunk arrived (the
+			// "O" race — see the streamDone comment on AppModel), the
+			// tick handler's new `!streamDone` guard would have kept it
+			// alive, so this append is safe to land without rescheduling.
 			m.typingContent += msg.Chunk.Content
 		}
 		// Chain the next read from the stream channel
@@ -1293,9 +1321,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case StreamDoneMsg:
-		// Clear cancel function — operation completed
+		// Clear cancel function — operation completed.
+		// Flip streamDone so the TickMsg tick-complete branch can commit
+		// the final content once the typing animation catches up.
 		m.cancelFunc = nil
 		m.interruptPending = false
+		m.streamDone = true
 		// Update token counts from API response
 		if msg.Usage != nil && (msg.Usage.PromptTokens > 0 || msg.Usage.CompletionTokens > 0) {
 			m.lastMsgInTok = msg.Usage.PromptTokens
@@ -1457,9 +1488,15 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.streamStart = time.Now().Add(-msg.Duration)
 			}
 			// Feed the response through SimulatedTyping — same path as regular chat.
+			// Agent responses are not streamed (the whole text arrives in one
+			// msg.Text), so mark streamDone=true up front: the TickMsg
+			// tick-complete branch will commit as soon as typing catches up
+			// instead of idling forever waiting for a StreamDoneMsg that the
+			// agent path never sends.
 			if strings.TrimSpace(msg.Text) != "" {
 				m.typingContent = msg.Text
 				m.typingPos = 0
+				m.streamDone = true
 				m.chat = m.chat.AddAssistantMessage("")
 				m.status = m.status.SetText("Agent: typing response...")
 				cmds = append(cmds, tea.Tick(typingTickInterval, func(t time.Time) tea.Msg {
@@ -1843,12 +1880,24 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = m.status.SetText(StreamingSpinner(m.animFrame) + " " + ThinkingAnimation(m.animFrame))
 
 			if m.typingPos < len(m.typingContent) {
-				// Schedule next typing tick
+				// More content to display — reschedule the typing tick.
+				cmds = append(cmds, tea.Tick(typingTickInterval, func(t time.Time) tea.Msg {
+					return TickMsg{Time: t}
+				}))
+			} else if !m.streamDone {
+				// Typing caught up to the end of the current buffer, but the
+				// network stream is still in flight — a late chunk may extend
+				// typingContent at any moment. Keep the ticker alive in an
+				// idle state so the next tick picks up any extension. Do NOT
+				// commit the content to session history yet; that's what
+				// caused the v1.9.0 "O" truncation bug. See the streamDone
+				// field doc on AppModel for the full story.
 				cmds = append(cmds, tea.Tick(typingTickInterval, func(t time.Time) tea.Msg {
 					return TickMsg{Time: t}
 				}))
 			} else {
-				// Typing complete - show final content without corruption
+				// Typing complete and stream is done — show final content
+				// without corruption and commit to session history.
 				m.chat = m.chat.SetLastAssistantContent(m.typingContent)
 
 				// Add assistant message to session for persistence
@@ -1866,6 +1915,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.typingContent = ""
 				m.typingPos = 0
 				m.streaming = false
+				m.streamDone = false
 				m.status = m.status.SetStreaming(false)
 				elapsed := time.Since(m.streamStart)
 				inTok, outTok := m.lastMsgInTok, m.lastMsgOutTok

--- a/cmd/celeste/tui/streaming_race_test.go
+++ b/cmd/celeste/tui/streaming_race_test.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamChunkThenTick_ShortFirstChunk_DoesNotCommitEarly reproduces the
+// v1.9.0 "O" truncation bug captured in
+// ~/.celeste/logs/celeste_2026-04-13.log. The scenario is:
+//
+//  1. First streaming chunk arrives carrying 1 character (e.g. "O").
+//     StreamChunkMsg with IsFirst=true starts the typing animation.
+//  2. The first TickMsg fires and advances typingPos by charsPerTick=3,
+//     which immediately exceeds len("O")=1. Pre-fix, the tick-complete
+//     branch committed "O" to session history and stopped the ticker.
+//  3. Subsequent chunks ("kay, here's the answer...") append to
+//     typingContent but find the ticker dead — nothing rendered them.
+//  4. The eventual StreamDoneMsg with the full 390-char FullContent
+//     updated typingContent but couldn't un-commit the already-persisted
+//     "O", leaving the TUI display and the session message both at 1 char.
+//
+// The fix: TickMsg now keeps the ticker alive when typingPos catches up
+// to len(typingContent) as long as streamDone==false, treating "caught up"
+// as idle rather than done. The commit branch only fires when BOTH
+// streamDone AND typingPos == len(typingContent) hold.
+func TestStreamChunkThenTick_ShortFirstChunk_DoesNotCommitEarly(t *testing.T) {
+	model := NewApp(nil)
+	model.currentSession = nil // no session persistence for this unit test
+
+	// Step 1: first chunk arrives with a single character.
+	m, _ := model.Update(StreamChunkMsg{
+		Chunk: StreamChunk{Content: "O", IsFirst: true},
+	})
+	mm := m.(AppModel)
+	require.True(t, mm.streaming, "streaming must be true after first chunk")
+	require.False(t, mm.streamDone, "streamDone must be false while stream is still in flight")
+	require.Equal(t, "O", mm.typingContent)
+
+	// Step 2: a TickMsg fires — pre-fix this would commit "O" and stop.
+	// With the fix, the tick-complete branch sees streamDone==false and
+	// keeps the ticker alive without committing.
+	m2, _ := mm.Update(TickMsg{})
+	mm2 := m2.(AppModel)
+	assert.True(t, mm2.streaming, "streaming must STILL be true after first tick caught up to 1-char buffer (ticker is idling, not committing)")
+	assert.Equal(t, "O", mm2.typingContent, "typingContent should still be the first chunk (no second chunk yet)")
+
+	// Step 3: second chunk arrives and extends the typing buffer.
+	m3, _ := mm2.Update(StreamChunkMsg{
+		Chunk: StreamChunk{Content: "kay, here's the full answer", IsFirst: false},
+	})
+	mm3 := m3.(AppModel)
+	assert.True(t, mm3.streaming)
+	assert.Equal(t, "Okay, here's the full answer", mm3.typingContent,
+		"second chunk must append to typingContent without overwriting")
+	assert.False(t, mm3.streamDone, "still waiting for StreamDoneMsg")
+
+	// Step 4: StreamDoneMsg arrives with the final full content — typing
+	// animation is still mid-drain. streamDone flips to true.
+	m4, _ := mm3.Update(StreamDoneMsg{
+		FullContent:  "Okay, here's the full answer",
+		FinishReason: "stop",
+	})
+	mm4 := m4.(AppModel)
+	assert.True(t, mm4.streamDone, "StreamDoneMsg must flip streamDone=true")
+	assert.Equal(t, "Okay, here's the full answer", mm4.typingContent,
+		"FullContent should be in typingContent after StreamDoneMsg")
+
+	// Step 5: keep ticking until typing catches up. With charsPerTick=3
+	// and a 28-char buffer we need at most 10 ticks to drain. The
+	// tick-complete branch will fire when typingPos == len(buffer) AND
+	// streamDone == true, committing the final content.
+	final := mm4
+	for i := 0; i < 20; i++ {
+		m5, _ := final.Update(TickMsg{})
+		final = m5.(AppModel)
+		if !final.streaming {
+			break
+		}
+	}
+	assert.False(t, final.streaming, "typing should finish within 20 ticks")
+	assert.False(t, final.streamDone, "streamDone should be reset to false after commit")
+	assert.Equal(t, "", final.typingContent, "typingContent should be cleared after commit")
+}
+
+// TestStreamChunkIsFirst_ResetsStreamDone verifies that starting a new
+// stream (IsFirst=true) resets streamDone to false so the tick-idle
+// behavior is re-armed for the new response.
+func TestStreamChunkIsFirst_ResetsStreamDone(t *testing.T) {
+	model := NewApp(nil)
+	model.streamDone = true // stale state from a previous stream
+
+	m, _ := model.Update(StreamChunkMsg{
+		Chunk: StreamChunk{Content: "new response", IsFirst: true},
+	})
+	mm := m.(AppModel)
+	assert.False(t, mm.streamDone, "starting a new stream must reset streamDone")
+	assert.True(t, mm.streaming)
+}
+
+// TestStreamDoneMsg_SetsStreamDone verifies the flag flip.
+func TestStreamDoneMsg_SetsStreamDone(t *testing.T) {
+	model := NewApp(nil)
+	model.streaming = true
+	model.typingContent = "partial"
+	model.typingPos = 3
+
+	m, _ := model.Update(StreamDoneMsg{
+		FullContent:  "partial content finalized",
+		FinishReason: "stop",
+	})
+	mm := m.(AppModel)
+	assert.True(t, mm.streamDone, "StreamDoneMsg must set streamDone=true")
+}
+
+// TestAgentResponse_SimulatedTyping_SetsStreamDone verifies that the
+// non-streaming agent response path also sets streamDone=true before
+// starting the typing animation. Without that, the tick-complete branch
+// would enter its new !streamDone idle loop and never commit the agent
+// reply to session history.
+func TestAgentResponse_SimulatedTyping_SetsStreamDone(t *testing.T) {
+	model := NewApp(nil)
+
+	m, _ := model.Update(AgentProgressMsg{
+		Kind:     AgentProgressResponse,
+		Text:     "the agent finished",
+		Duration: 0,
+	})
+	mm := m.(AppModel)
+	assert.True(t, mm.streamDone, "agent response path must set streamDone=true before typing")
+	assert.Equal(t, "the agent finished", mm.typingContent)
+}
+
+// Silence unused-import if any assertion above is removed later.
+var _ = tea.Msg(nil)


### PR DESCRIPTION
## Summary

Hotfix PR for **v1.9.1**. Addresses a TUI streaming race where a short first SSE chunk (1-3 chars) caused the typing animation to commit the assistant reply to session history before the stream had actually finished, leaving the rest of the response piled up in a zombie buffer with no ticker to drain it.

Captured in a real session log at \`~/.celeste/logs/celeste_2026-04-13.log\`:

\`\`\`
[2026-04-13 22:56:25] LLM_RESPONSE: 390 chars, no tool calls       ← grok sent full response
[2026-04-13 22:56:42] Message[6]: role=assistant, content_len=1    ← TUI committed only "O"
\`\`\`

## Root cause

\`cmd/celeste/tui/app.go\` constants:
\`\`\`go
const charsPerTick = 3
const typingTickInterval = 50 * time.Millisecond
\`\`\`

Race:
1. First SSE chunk arrives with a single character (e.g. \`\"O\"\`)
2. \`StreamChunkMsg\` handler starts typing animation with \`typingContent = \"O\"\`, \`typingPos = 0\`, schedules first \`TickMsg\`
3. First tick fires after 50ms, advances \`typingPos += 3\`, clamps to \`len(\"O\") = 1\`
4. Tick-complete branch saw \`typingPos == len(typingContent)\` and **unconditionally committed** — appended \`{Role: \"assistant\", Content: \"O\"}\` to session, flipped \`streaming=false\`, did not reschedule the ticker
5. Subsequent chunks arrived but landed in a zombie \`typingContent\` buffer that nobody was rendering
6. \`StreamDoneMsg\` at the end couldn't recover because the session message was already persisted

Consequence: the TUI display froze at \"O\", session file stored \"O\", and the next turn's LLM request sent \`content_len=1\` for that assistant message — losing 389 characters of real response.

## Fix

Add an \`AppModel.streamDone bool\` that tracks \"the LLM stream has reported \`EventMessageDone\` for the current response\". The \`TickMsg\` tick-complete branch now has three cases instead of two:

| typingPos vs len | streamDone | Action |
|---|---|---|
| \`pos < len\` | any | advance + reschedule (unchanged) |
| \`pos == len\` | \`false\` | **idle: reschedule a no-op tick** so any late chunk gets picked up automatically |
| \`pos == len\` | \`true\` | commit to session + stop (the original termination path, now gated) |

- \`StreamChunkMsg\` with \`IsFirst=true\` resets \`streamDone=false\`
- \`StreamDoneMsg\` handler sets \`streamDone=true\` before returning
- \`AgentProgressResponse\` (non-streaming agent reply path that reuses the typing animation) sets \`streamDone=true\` up front so its animation commits immediately on catch-up — otherwise the new idle loop would spin forever waiting for a \`StreamDoneMsg\` that the agent path never sends

## Tests

Four new regression tests in \`cmd/celeste/tui/streaming_race_test.go\`:

- \`TestStreamChunkThenTick_ShortFirstChunk_DoesNotCommitEarly\` — the exact log reproduction
- \`TestStreamChunkIsFirst_ResetsStreamDone\` — stale flag from previous stream is cleared on new IsFirst
- \`TestStreamDoneMsg_SetsStreamDone\` — flag flip on message-done
- \`TestAgentResponse_SimulatedTyping_SetsStreamDone\` — agent response path primes the flag

All four pass. Pre-existing \`TestAgentProgressResponseTriggersTypingAnimation\` stays green. Full TUI suite green.

\`gofmt -l .\` clean. \`go vet ./...\` clean.

## Test plan

- [ ] All CI matrix jobs pass (Test ubuntu/macos/windows/1.26.2, Lint, Security Scan, Docker, Build)
- [ ] After merge + tag v1.9.1, Release workflow produces signed cross-platform binaries
- [ ] Manual smoke: \`go install github.com/whykusanagi/celeste-cli/cmd/celeste@v1.9.1\`, run TUI chat, ask grok a question where the first streamed delta will be a single character — verify full response renders and persists

## Scope

This is the **only** fix for v1.9.1. Everything else in v1.9.0 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)