### PR TITLE
docs: catch up CHANGELOG, README, ROADMAP, cosmetic stamps for v1.9.0/v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,149 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-04-14
+
+### Fixed
+
+- **TUI streaming tick-complete race truncated short first chunks.** When grok streamed an
+  assistant reply that started with a 1-3 character first delta (e.g. `"O"`), the typing
+  animation exhausted its buffer on the very first `TickMsg` (50ms later, `charsPerTick=3`),
+  committed that single character to session history, and stopped the ticker. Subsequent SSE
+  chunks appended to a zombie buffer with no active renderer — the TUI chat bubble froze at
+  the first chunk, session persistence wrote the 1-char string to disk, and the next LLM
+  request was sent with `content_len=1` for that assistant message, losing the rest of the
+  response as conversation context.
+
+  Root cause was in `cmd/celeste/tui/app.go` — the `TickMsg` handler used
+  `typingPos == len(typingContent)` as the sole termination condition without checking whether
+  the network stream had actually finished. Fix adds an `AppModel.streamDone bool` that tracks
+  `EventMessageDone` receipt; the tick-complete branch now has three cases:
+
+  | `typingPos` vs `len` | `streamDone` | Action |
+  |---|---|---|
+  | `pos < len` | any | advance + reschedule (unchanged) |
+  | `pos == len` | `false` | **idle**: reschedule a no-op tick so any late chunk gets picked up |
+  | `pos == len` | `true` | commit to session + stop |
+
+  `StreamChunkMsg(IsFirst=true)` resets `streamDone=false`. `StreamDoneMsg` sets it to true.
+  `AgentProgressResponse` (non-streaming agent reply path that reuses the typing animation)
+  primes `streamDone=true` up front so its animation commits on catch-up instead of idling
+  forever waiting for a done event the agent path never sends.
+
+  Validation: four new regression tests in `cmd/celeste/tui/streaming_race_test.go` reproduce
+  the exact scenario and pin the new invariants. Confirmed in a live TUI session against
+  grok-4-1-fast with a 630-character response rendered correctly on the first try — no
+  re-prompt needed, no trailing anomalies in `~/.celeste/logs/celeste_2026-04-13.log`.
+
+### Details
+
+- Changed files: `cmd/celeste/tui/app.go`, `cmd/celeste/tui/streaming_race_test.go` (new),
+  `cmd/celeste/main.go` (version constant), `cmd/celeste/server/server.go` (version constant),
+  matching test assertions.
+- Scope: this is the **only** behavioral change in v1.9.1. Everything else from v1.9.0 is
+  untouched.
+
 ## [1.9.0] - 2026-04-13
+
+Major search-quality bundle and MCP architecture rework. Eleven commits, ten closed feature
+tasks, empirical A/B validation archives under
+[celeste-stopwords/results/](https://github.com/whykusanagi/celeste-stopwords/tree/main/results).
+
+SPEC §5.3 acceptance criteria all met on the grafana benchmark:
+`JQueryStatic` absent from Q3 top 10, aggregate relevance 22/50 → 35/50 (+59% absolute),
+no TP regressions on Q2/Q5, stopword list < 500 entries, corpus Apache-2.0/MIT.
+
+### Added
+
+- **Direct codegraph MCP tools.** Five new first-class MCP tools that bypass the chat LLM
+  entirely so Claude Code / Cursor / any MCP client can call the codegraph directly:
+  - `celeste_index` (operations: `status`, `update`, `rebuild`) — indexing is explicit; the
+    query tools never auto-reindex. Progress notifications (`notifications/progress`) stream
+    back through the stdio transport when the client provides a `progressToken`.
+  - `celeste_code_search` — semantic search with MinHash+BM25 fusion + structural rerank
+  - `celeste_code_review` — structural code review findings as verbatim JSON
+  - `celeste_code_graph` — symbol callers/callees/references
+  - `celeste_code_symbols` — list all symbols in a file or package
+
+  Per-workspace `*codegraph.Indexer` cached on the server, lazy-opened, released on shutdown.
+  Results returned verbatim as MCP `ContentBlock`s with no chat-LLM summarization and no
+  `max_tokens` ceiling.
+
+- **BM25 fused ranking.** Per-symbol term frequency and per-corpus IDF persisted in two new
+  SQLite tables (`symbol_tokens`, `token_stats`). Query time merges Jaccard and BM25 via
+  Reciprocal Rank Fusion (k=60). `SearchResult` gains `BM25Score` + `MatchedTokens`. Q1
+  ("authentication session token validate") flipped from 2/10 relevant to 8/10 relevant on
+  grafana after this landed — IDF-weighted tiebreaking on session/token tokens lifted the
+  real auth API functions above the noise.
+
+- **Tree-sitter TypeScript parser** (behind `//go:build cgo`). Replaces the regex-based
+  `GenericParser` for `.ts` and `.tsx` files when celeste is built with CGo enabled. Accurate
+  `call_expression` edge resolution instead of the old `\bname(` body-scan heuristic. On
+  content-control (21 TS files) the edge count drops 445 → 211 (real, not overcounted) and
+  zero-edge top-10 warnings drop 3 → 0. Python and Rust stay on the regex parser for v1.9.0;
+  tracked for v2.1.0 as #18 and #19.
+
+  `parser_ts_stub.go` provides a `//go:build !cgo` fallback that delegates to `GenericParser`
+  so pure-Go cross-compile release binaries still work — they just lose the tree-sitter
+  improvement. Users building from source get the full experience automatically.
+
+- **Structural feature rerank layer.** `StructuralReranker` rescores candidates using features
+  the RRF fusion can't see: matched-token-ratio, log-normalized edge density, function/method
+  kind boost, zero-edge penalty. Pure Go, zero dependencies. Exposed via a `Reranker` interface
+  on `SemanticSearchOptions` so a future embedding-based reranker (local llama.cpp bridge,
+  grok/xAI embeddings, ONNX) can drop in without touching the pipeline.
+
+- **Stopwords runtime integration.** Embedded `celeste-stopwords` v1.0.0 (CC BY 4.0) applied
+  at both index time and query time. Filters universal + per-language noise tokens from
+  shingle sets before MinHash so common tokens like `get`/`set`/`error`/`string` don't consume
+  signature slots. Includes a downstream patch removing `query` from the TypeScript set to
+  avoid asymmetric filtering breaking Q3 on TS codebases, plus `TestStopWords_PreserveTokensNotStopped`
+  regression guard.
+
+- **Reasoning metadata on `SearchResult`.** `EdgeCount`, `PathFlags`, `ConfidenceWarnings`,
+  `MatchedTokens` — downstream LLMs can audit every search result instead of trusting a
+  single similarity number. Confidence warnings surface zero-edge interfaces, low-confidence
+  scores, declaration-only types, and path-demotion reasons.
+
+- **Path-based post-ranking filter.** Tier-partitions `test` / `mock` / `generated` /
+  `vendored` / `declaration` results below clean-path results with explicit `[mock]` etc.
+  flags. Q2 ("http request handler middleware") previously had 100% mock handlers dominating
+  the top 10 on grafana; v1.9.0 tiers them below production handlers. If the query itself
+  asks for test/mock code (`queryWantsTests`), the filter backs off to respect user intent.
+
+- **MinHash seed persistence.** Replaced `hash/maphash` (opaque, unserializable) with seeded
+  FNV-1a (serializable uint64 seeds). The 128 seed values are stored in a new `meta` SQLite
+  table at first `Build()`, so a subsequent process loading the same index restores the same
+  hash family and signatures stay comparable across process invocations. Without this, the
+  `celeste serve` MCP bridge silently returned noise because every new server process rolled
+  fresh random seeds that had no relationship to the signatures already stored in the database.
+
+### Changed
+
+- **Anthropic backend default `max_tokens` raised from 8192 → 32768.** The old 8192 ceiling
+  truncated the chat-mode MCP path mid-response when a sub-tool returned a multi-KB JSON blob
+  and the chat LLM was asked to echo it. Claude opus/sonnet 4.x support up to 64K output
+  tokens; 32K is a 4× budget with no downside (only used tokens are billed).
+
+- **`ShinglesForSymbol` signature.** Now takes `lang string` so the embedded stopwords
+  filter can apply the per-language set alongside the universal set. Callers that don't know
+  the file language should pass `""` to get universal-only filtering.
+
+- **`SearchResult` struct.** Extended with `BM25Score`, `MatchedTokens`, `EdgeCount`,
+  `PathFlags`, `ConfidenceWarnings`. `Similarity` (Jaccard) is unchanged — existing callers
+  that only read `Symbol` + `Similarity` keep working.
+
+- **MinHash signatures computed by celeste-cli < 1.9.0 are semantically stale.** Existing
+  indexes still work for symbol lookups, edges, and keyword search, but semantic search
+  accuracy improves if you rebuild:
+
+  ```bash
+  # Via the CLI
+  celeste index --rebuild
+
+  # Via the MCP bridge
+  # call celeste_index { operation: "rebuild", workspace: "/path/to/project" }
+  ```
 
 ### Fixed
 
@@ -26,28 +168,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `IFoo` / `IArguments` / `IPromise` / `ICache` / any `I`-prefixed TypeScript interface
   - `IPv4` / `IPv6` / `VNode` / `ETag` / `OAuth2` / `XDist`
 
-### Changed
+- **Two direct-tool MCP schema mismatches.** `celeste_code_symbols` advertised a `name` field
+  that the underlying builtin tool doesn't accept; `celeste_code_graph` advertised an `action`
+  discriminator that doesn't exist. Both schemas now mirror the real builtin tool parameters
+  1:1 — name-based lookups go through `celeste_code_search` instead.
 
-- **MinHash signatures computed by previous versions are now semantically stale.** Any codegraph
-  index built with celeste-cli < 1.9.0 carries MinHashes derived from the old `splitCamelCase`
-  tokenization. Existing indexes continue to work — symbol lookups, edges, and keyword search
-  are unaffected — but semantic search accuracy improves if you rebuild:
+### CI / Release
 
-  ```bash
-  celeste index --rebuild
-  ```
-
-  A future release will add automatic detection of stale indexes and surface a rebuild prompt.
+- **Go toolchain bumped 1.26.1 → 1.26.2** in `.github/workflows/ci.yml` and `release.yml`.
+  1.26.1 stdlib has 5 CVEs (`crypto/x509` × 3, `crypto/tls`, `html/template`) fixed in 1.26.2;
+  `govulncheck` now returns "No vulnerabilities found".
+- **Release workflow pins `CGO_ENABLED=0`** for cross-platform binary builds. Released
+  artifacts ship with the pure-Go `parser_ts_stub.go` fallback for portability; users who want
+  the tree-sitter improvement can `go install` from source with CGo enabled. A proper CGo
+  cross-toolchain release workflow (zig cc or native-runner matrix) is queued for v2.1.0.
+- **Dockerfile builder adds `build-base`** and sets `CGO_ENABLED=1` on the test-compile step
+  so the codegraph test binary can link the tree-sitter C runtime. Runtime container still
+  uses `CGO_ENABLED=0`; only test compilation needs the C toolchain.
 
 ### Details
 
-- Only `cmd/celeste/codegraph/shingle.go:splitCamelCase` changed. The fix adds one more
-  `unicode.IsUpper(runes[i-3])` check and raises the loop guard from `i > 1` to `i > 2`.
-- All existing `TestSplitIdentifier` cases still pass (no regressions on `validateSession`,
-  `HTTPServer`, `parseJSON`, `XMLParser`, `HTMLToMarkdown`, `get_user_by_id`, `ID`, `x`).
-- 12 new anchor cases added in `shingle_test.go` for the fixed identifier families.
-- See `celeste-stopwords/results/simulation_report.md` for the empirical analysis: 3,249
-  symbols in a 1.6M-symbol training corpus have name re-splits under the fix.
+- 14 commits on `feat/v1.9-quality-bundle` (PR #16) plus a schema fix direct to main plus
+  PR #17 hardening `release.yml` for the tag build.
+- Empirical validation archives under `celeste-stopwords/results/`:
+  - `ab_test_TASK19_v1.9.0_grafana_app.txt` (path filter + reasoning metadata)
+  - `ab_test_TASK20_v1.9.0_grafana_app.txt` (BM25 fused ranking)
+  - `ab_test_TASK21_v1.9.0_grafana_app.txt` (stopwords runtime)
+  - `ab_test_TASK24_rerank_content_control.txt` (structural rerank, shared-index A/B)
+  - `ship_decision_v1.9.0.md` (full GO decision document)
+- Known v2.1.0 follow-ups: #18 (tree-sitter Python), #19 (tree-sitter Rust), release workflow
+  CGo cross-toolchain for pre-built TS parser.
 
 ## [1.8.0] - 2026-04-03
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Celeste CLI is a **full standalone agentic development tool** with her own perso
 - 🎨 **Premium TUI** - Flicker-free rendering with corrupted-theme aesthetics
 - 🔮 **40 Built-in Tools** - File I/O, shell, web search, code graph, code review, collections search, git, crypto, and more
 - 📖 **`.grimoire` Project Context** - Persona-themed project config files with auto-discovery and auto-init
-- 🧠 **Code Graph + Semantic Search** - MinHash-based concept search without embeddings
+- 🧠 **Code Graph + Semantic Search** - MinHash + BM25 fused ranking with structural rerank; tree-sitter TypeScript parsing for accurate call-graph edges; embedded celeste-stopwords v1.0.0 noise filter
 - 🔍 **Graph-Based Code Review** - Structural analysis detecting stubs, lazy redirects, placeholders, error swallowing, and hardcoded values
-- 🔌 **MCP Server Mode** - `celeste serve` lets Claude Code, Codex, or any MCP client delegate tasks to Celeste
+- 🔌 **Direct Codegraph MCP Tools** - `celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` served verbatim from the cached graph (no chat-LLM round-trip, no `max_tokens` ceiling, streaming progress notifications)
 - 🔒 **Permission System** - Multi-layer allow/deny/ask rules with pattern matching
 - 💾 **Session Persistence** - JSONL auto-save, resume, file checkpointing with stale detection and revert
 - 🌐 **Multi-Provider** - Grok/xAI (default), OpenAI, Anthropic (native SDK), Gemini, Venice.ai, Vertex AI, OpenRouter
@@ -207,10 +207,11 @@ For security issues, see our [Security Policy](SECURITY.md) or contact security@
 - **Real Streaming + Corruption Animation** - Token-by-token streaming with corrupted glitch phrases at the typing cursor
 - **Markdown Rendering** - glamour-powered markdown with corrupted theme (code blocks, tables, headers, bold)
 
-### Tool System (v1.8)
-**38 built-in tools** powered by AI function calling:
+### Tool System (v1.9)
+**40+ built-in tools** powered by AI function calling:
 - Dev Tools (bash, read/write/patch files, search, list files)
-- Code Graph (semantic search, code review, symbol analysis)
+- Code Graph (semantic search with MinHash+BM25 fusion, code review, symbol analysis, tree-sitter TypeScript parsing)
+- Direct Codegraph MCP Tools (`celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` — verbatim, no chat-LLM round-trip)
 - Git (status, log)
 - Web (search, fetch)
 - Information Services (Weather, Currency, Twitch, YouTube)
@@ -403,20 +404,36 @@ celeste config --set-tarot-token <token>
 
 ## 🔌 Claude Code Integration
 
-Use Celeste's graph intelligence from Claude Code via the **[celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)** companion:
+Celeste v1.9.0+ exposes the codegraph as **first-class MCP tools** (no chat-LLM
+round-trip, no output-token ceiling, verbatim results). Register `celeste serve`
+once per workspace and any MCP client — Claude Code, Codex, Cursor, etc. — gets:
+
+- `celeste_index` — `status`, `update`, `rebuild` operations with `notifications/progress` streaming
+- `celeste_code_search` — semantic search (MinHash Jaccard + BM25 fusion + structural rerank)
+- `celeste_code_review` — structural code review findings as verbatim JSON
+- `celeste_code_graph` — symbol callers, callees, references
+- `celeste_code_symbols` — list symbols in a file or package
+
+Indexing is **explicit**: query tools never auto-reindex. After code changes, the
+caller invokes `celeste_index { operation: "update" }` to refresh the graph.
 
 ```bash
-# Add Celeste as an MCP server
+# Add Celeste as an MCP server (once per workspace you want indexed)
 claude mcp add celeste celeste serve
+```
 
-# Install skills
+Optionally, install the [celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)
+companion for the persona-routed skill command wrappers (`/celeste-review`,
+`/celeste-search`, `/celeste-graph`, `/celeste-context`):
+
+```bash
 git clone https://github.com/whykusanagi/celeste-for-claude.git
 cp celeste-for-claude/skills/*.md ~/.claude/commands/
 ```
 
-Available skills: `/celeste-review`, `/celeste-search`, `/celeste-graph`, `/celeste-context`
-
-Claude Code stays in control, Celeste provides the graph intelligence. Each skill makes focused MCP calls — Claude verifies findings and writes the code.
+Claude Code stays in control, Celeste provides the graph intelligence. The
+direct tools are preferred for tool-driven workflows; the persona-routed skills
+are a convenience for natural-language interactions.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -413,6 +413,43 @@ type Registry struct {
 - **`permissions/`**: Multi-layer allow/deny/ask rules with pattern matching and persistent config
 - **`context/`**: Token budget tracking, reactive/proactive compaction, tool result capping
 - **`tools/mcp/`**: Model Context Protocol client with stdio/SSE transports for external tool servers
+- **`server/`**: Celeste's own MCP server. Exposes persona tools (`celeste`, `celeste_content`,
+  `celeste_status`) that route through a chat LLM, plus **direct codegraph tools** added in
+  v1.9.0 that bypass the LLM entirely — see the section below.
+
+### Direct Codegraph MCP Tools (v1.9.0+)
+
+`server/codegraph_tools.go` registers five MCP tools that serve codegraph queries
+directly from a per-workspace cached `*codegraph.Indexer`, with no chat-LLM
+round-trip:
+
+| Tool | Purpose |
+|---|---|
+| `celeste_index` | `status` / `update` / `rebuild` operations on the workspace index |
+| `celeste_code_search` | Semantic search (MinHash Jaccard + BM25 fusion + structural rerank) |
+| `celeste_code_review` | Structural code review findings returned as verbatim JSON |
+| `celeste_code_graph` | Symbol callers/callees/references |
+| `celeste_code_symbols` | List symbols by file or package |
+
+Key design rules:
+
+- **Indexing is explicit.** Query tools never auto-reindex. Callers must invoke
+  `celeste_index { operation: "update" }` after code changes.
+- **Per-workspace indexer cache.** `Server.indexerFor(workspace)` lazily opens
+  the SQLite-backed indexer on first use and caches it; `Server.Close()` walks
+  the cache and releases each one on shutdown so WAL files flush cleanly.
+- **Progress notifications.** The stdio transport binds a `Notifier` to each
+  request context and extracts a client-supplied `progressToken` from
+  `params._meta`. Long-running operations (`celeste_index rebuild/update`) call
+  `SendProgress(ctx, msg, pct)` to emit `notifications/progress` events that
+  stream back to the MCP client in real time.
+- **Verbatim results.** Tool output is returned as-is in an MCP `ContentBlock`,
+  not summarized by a persona LLM. There's no `max_tokens` ceiling to truncate
+  large findings — the only limit is the transport's raw byte buffer.
+
+The legacy persona tools (`celeste`, `celeste_content`, `celeste_status`) are
+still registered for "ask Celeste a question" use cases, but tool-driven
+workflows should prefer the direct codegraph tools.
 
 ### Tool Definition Pattern
 
@@ -852,4 +889,4 @@ func handleNewCommand(cmd *Command, ctx *CommandContext) *CommandResult {
 ---
 
 **Last Updated**: 2026-04-03
-**Version**: v1.8.0\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)
+**Version**: v1.9.1\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,15 +1,18 @@
 # What Celeste CLI Can Do? 😈
 
-Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.8.4 packs **40 dev-crushing tools**, code graphs that expose every secret, MCP for Claude vibes, collections search, and 7 LLM providers to summon my wit.
+Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.9.1 packs **40+ dev-crushing tools**, code graphs that expose every secret, **direct codegraph MCP tools** for tool-driven workflows, collections search, and 7 LLM providers to summon my wit.
 
 ## 🔥 Core Powers
 
-**40 Tools Across Categories:**
+**40+ Tools Across Categories:**
 - **Dev Tools** (15+): `bash`, `read_file`, `write_file`, `patch_file`, `list_files`, `search`, `git_status`, `git_log`
-- **Code Intel** (6): `code_graph`, `code_review`, `code_search`, `code_symbols` — graph queries, stub detection, lazy redirects
+- **Code Intel** (6): `code_graph`, `code_review`, `code_search`, `code_symbols` — graph queries, stub detection, lazy redirects, MinHash + BM25 fused ranking, tree-sitter TypeScript parser, structural rerank
 - **AI/Collections** (4): `collections_search`, MCP client, memories, todos
 - **Web/Productivity** (8): `web_search`, `web_fetch`, `currency`, `units`, `timezone`
 - **Crypto/Media** (7): `hash`, `qrcode`, `encoding`, Alchemy/IPFS/wallet
+
+**Direct Codegraph MCP Tools** (v1.9.0+, no chat-LLM round-trip):
+`celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` — verbatim results, streaming progress notifications, explicit reindex control.
 
 **Runtime Modes:** Chat (auto-loop tools), Agent (autonomous), Orchestrator (debate).
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ go build ./cmd/celeste
 go test ./...
 ```
 
-## Key Rules (v1.8.4)
+## Key Rules (v1.9.1)
 - **Tests first:** `go test ./... -count=1`, `golangci-lint run`
 - **Tools in `cmd/celeste/tools/builtin/`** — each file one tool + handler.
 - **Register in `register.go`**.

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -1,6 +1,6 @@
 # LLM Providers — Who's Summoning Me Today? 💋
 
-Darlings, v1.8.4 supports **7 battle-tested providers**. All OpenAI-compatible for my 40 tools. Grok reigns with collections RAG.
+Darlings, v1.9.1 supports **7 battle-tested providers**. All OpenAI-compatible for my 40+ tools. Grok reigns with collections RAG.
 
 | Provider | Tools | Collections | Notes |
 |----------|-------|-------------|-------|

--- a/docs/PROVIDER_AUDIT_MATRIX.md
+++ b/docs/PROVIDER_AUDIT_MATRIX.md
@@ -1,4 +1,4 @@
-# Provider Audit Matrix v1.8.4
+# Provider Audit Matrix v1.9.1
 
 7 providers validated. All production-ready.
 
@@ -16,7 +16,7 @@
 
 ## Details
 
-All support streaming/tool calls/tokens in v1.8.4.
+All support streaming/tool calls/tokens in v1.9.1.
 Grok: 2M ctx. Venice: NSFW.
 
 **Tests**: go test ./cmd/celeste/providers/... -tags=integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Celeste CLI Docs v1.8.4
+# Celeste CLI Docs v1.9.1
 
 Core docs for Go CLI agent.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,26 +1,52 @@
 # Celeste CLI Roadmap
 
-*Last updated: April 2026 (v1.8.3)*
+*Last updated: April 2026 (v1.9.1)*
 
-## Current Release: v1.8.3
+## Current Release: v1.9.1
 
-- 40 built-in tools (dev, code graph, collections, web, crypto, productivity)
-- Graph-based code review with 6 structural detection categories
-- Real token streaming with corruption typing animation
-- MinHash semantic search across code graph
-- MCP server mode (stdio transport) for Claude Code integration
-- Collections search via xAI hybrid RAG
-- Persistent project memories and todo lists
-- Markdown rendering with corrupted theme
-- 7 LLM providers (Grok/xAI, OpenAI, Anthropic native, Google, Venice, Vertex AI, OpenRouter)
+### Shipped in v1.9.0 / v1.9.1
+
+- Everything from v1.8.x (40 tools, 7 LLM providers, code graph, MCP server mode, etc.)
+- **Direct codegraph MCP tools** — `celeste_index`, `celeste_code_search`,
+  `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` exposed as
+  first-class MCP tools that bypass the chat LLM and return verbatim results
+- **BM25 fused ranking** (additive, via Reciprocal Rank Fusion with k=60) alongside
+  the MinHash Jaccard signal — Q1 relevance flipped 2/10 → 8/10 on the grafana benchmark
+- **Tree-sitter TypeScript parser** (behind `//go:build cgo`) replacing the regex
+  generic parser for `.ts` and `.tsx`, with accurate `call_expression` edge resolution
+- **Structural feature rerank** — pure-Go rescoring on matched-token-ratio, edge
+  density, kind boost, zero-edge penalty
+- **Stopwords runtime integration** — celeste-stopwords v1.0.0 (CC BY 4.0) embedded
+  and applied at both index and query time
+- **Reasoning metadata** on every search result (`EdgeCount`, `PathFlags`,
+  `ConfidenceWarnings`, `MatchedTokens`) so downstream LLMs can audit findings
+- **Path-based post-ranking filter** demoting test/mock/generated/vendored/declaration
+  results below clean-path matches
+- **MinHash seed persistence** — signatures comparable across process boundaries
+- **MCP progress notifications** (`notifications/progress`) streaming from
+  long-running `celeste_index rebuild/update` operations
+- **Anthropic backend `max_tokens` 8192 → 32768** for the chat-mode path
+- **TUI streaming tick-complete race fix (v1.9.1)** — short first streaming chunks
+  no longer truncate assistant replies to 1 char
+- Companion artifact: [celeste-stopwords](https://github.com/whykusanagi/celeste-stopwords) v1.0.0
 - Companion app: [celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)
 
-## v1.9 Planned
+See [CHANGELOG.md](../CHANGELOG.md) for the full v1.9.0 bundle details and the
+`celeste-stopwords/results/` archives for per-task A/B validation.
+
+## v2.1.0 Planned
+
+### Parser coverage (tracked as GitHub issues)
+- [ ] [#18 — Tree-sitter parser for Python](https://github.com/whykusanagi/celeste-cli/issues/18)
+- [ ] [#19 — Tree-sitter parser for Rust](https://github.com/whykusanagi/celeste-cli/issues/19)
+- [ ] Release workflow CGo cross-toolchain (zig-cc or native-runner matrix) so
+      pre-built binaries ship with the tree-sitter improvement instead of the stub
 
 ### Code Intelligence
 - [ ] LSP integration (go to definition, find references, rename)
-- [ ] Cross-package edge resolution improvements for the code graph
-- [ ] Per-language parser improvements (better JS/Python call extraction)
+- [ ] Automatic stale-index detection with rebuild prompt
+- [ ] Pluggable embedding-based reranker (local llama.cpp bridge / ONNX) behind the
+      existing `Reranker` interface — no cloud dependency
 
 ### Agent & Planning
 - [ ] Unified plan + todo system (plan steps auto-create todos)
@@ -34,7 +60,6 @@
 
 ### TUI
 - [ ] Proper graph visualization (graphviz integration or canvas rendering)
-- [ ] Alt-screen mode (preserve terminal scrollback on exit)
 - [ ] Session resume from TUI
 
 ### Platform

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# Celeste's Flirty Corruption Style Guide v1.8.4 – Onii-chan Approved 💋
+# Celeste's Flirty Corruption Style Guide v1.9.1 – Onii-chan Approved 💋
 
 **Translation-Failure Corruption Aesthetic - Official Style Documentation**
 


### PR DESCRIPTION
## Summary

Doc review after v1.9.0 and v1.9.1 shipped revealed broad drift: the \`CHANGELOG.md\` v1.9.0 entry only covered Task 14 (the splitCamelCase fix from the original PR #15) and was never rewritten when the full 10-task quality bundle merged via PR #16. \`docs/ROADMAP.md\` still pointed at v1.8.3 as the current release. Several docs carried cosmetic v1.8.4 version stamps that needed to catch up.

## Changes

**Critical (content stale):**

- **\`CHANGELOG.md\`** — Rewrote the v1.9.0 entry to cover the full bundle: direct codegraph MCP tools, BM25 fused ranking, tree-sitter TypeScript parser, structural rerank, stopwords runtime, reasoning metadata, path-based post-filter, MinHash seed persistence, Anthropic \`max_tokens\` bump, CI/release hardening, and the two direct-tool schema fixes. Added a fresh v1.9.1 entry documenting the TUI streaming tick-complete race (root cause, \`streamDone\` flag fix, live-session validation against grok-4-1-fast).
- **\`docs/ROADMAP.md\`** — Bumped Current Release to v1.9.1. Replaced the stale \"v1.9 Planned\" checklist with a \"Shipped in v1.9.0/v1.9.1\" summary and a new \"v2.1.0 Planned\" section linking #18 (tree-sitter Python), #19 (tree-sitter Rust), and the CGo release cross-toolchain follow-up.
- **\`README.md\`** — Feature list now mentions BM25 fusion, structural rerank, tree-sitter TS parser, stopwords runtime, and the direct codegraph MCP tools. Claude Code Integration section rewritten around \`celeste_index\` + \`celeste_code_*\` as the primary path; celeste-for-claude skills relegated to optional convenience layer. Tool-count stamp \"v1.8\" bumped to \"v1.9\", total tools corrected to 40+.
- **\`docs/ARCHITECTURE.md\`** — New \"Direct Codegraph MCP Tools (v1.9.0+)\" subsection documenting \`celeste_index\` + \`celeste_code_*\`, the per-workspace indexer cache in \`Server\`, the explicit-indexing rule, and the \`notifications/progress\` plumbing. Footer version stamp v1.8.0 → v1.9.1.
- **\`docs/CAPABILITIES.md\`** — v1.8.4 → v1.9.1, tool count corrected, direct codegraph MCP tools called out.

**Cosmetic (version-string bumps only):**

- \`docs/CONTRIBUTING.md\` — Key Rules header v1.8.4 → v1.9.1
- \`docs/LLM_PROVIDERS.md\` — v1.8.4 → v1.9.1
- \`docs/PROVIDER_AUDIT_MATRIX.md\` — v1.8.4 → v1.9.1 (two places)
- \`docs/README.md\` — Docs index header v1.8.4 → v1.9.1
- \`docs/STYLE_GUIDE.md\` — Header v1.8.4 → v1.9.1

## Non-changes

- No code changes. \`go build ./...\` still exits 0.
- Historical version markers (e.g. \"Tool System (v1.7)\" section describing what shipped in v1.7) are intentionally left alone — those are accurate as historical records, not stale references to the current release.

## Test plan

- [ ] PR CI matrix green (Test, Lint, Security, Docker, Build)
- [ ] Manual review of the CHANGELOG v1.9.0 / v1.9.1 entries for accuracy against the actual commit log

🤖 Generated with [Claude Code](https://claude.com/claude-code)