### PR TITLE
v1.9.2: LSH band table + TUI /index rebuild + /config set-* subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,149 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-04-14
+
+### Fixed
+
+- **TUI streaming tick-complete race truncated short first chunks.** When grok streamed an
+  assistant reply that started with a 1-3 character first delta (e.g. `"O"`), the typing
+  animation exhausted its buffer on the very first `TickMsg` (50ms later, `charsPerTick=3`),
+  committed that single character to session history, and stopped the ticker. Subsequent SSE
+  chunks appended to a zombie buffer with no active renderer — the TUI chat bubble froze at
+  the first chunk, session persistence wrote the 1-char string to disk, and the next LLM
+  request was sent with `content_len=1` for that assistant message, losing the rest of the
+  response as conversation context.
+
+  Root cause was in `cmd/celeste/tui/app.go` — the `TickMsg` handler used
+  `typingPos == len(typingContent)` as the sole termination condition without checking whether
+  the network stream had actually finished. Fix adds an `AppModel.streamDone bool` that tracks
+  `EventMessageDone` receipt; the tick-complete branch now has three cases:
+
+  | `typingPos` vs `len` | `streamDone` | Action |
+  |---|---|---|
+  | `pos < len` | any | advance + reschedule (unchanged) |
+  | `pos == len` | `false` | **idle**: reschedule a no-op tick so any late chunk gets picked up |
+  | `pos == len` | `true` | commit to session + stop |
+
+  `StreamChunkMsg(IsFirst=true)` resets `streamDone=false`. `StreamDoneMsg` sets it to true.
+  `AgentProgressResponse` (non-streaming agent reply path that reuses the typing animation)
+  primes `streamDone=true` up front so its animation commits on catch-up instead of idling
+  forever waiting for a done event the agent path never sends.
+
+  Validation: four new regression tests in `cmd/celeste/tui/streaming_race_test.go` reproduce
+  the exact scenario and pin the new invariants. Confirmed in a live TUI session against
+  grok-4-1-fast with a 630-character response rendered correctly on the first try — no
+  re-prompt needed, no trailing anomalies in `~/.celeste/logs/celeste_2026-04-13.log`.
+
+### Details
+
+- Changed files: `cmd/celeste/tui/app.go`, `cmd/celeste/tui/streaming_race_test.go` (new),
+  `cmd/celeste/main.go` (version constant), `cmd/celeste/server/server.go` (version constant),
+  matching test assertions.
+- Scope: this is the **only** behavioral change in v1.9.1. Everything else from v1.9.0 is
+  untouched.
+
 ## [1.9.0] - 2026-04-13
+
+Major search-quality bundle and MCP architecture rework. Eleven commits, ten closed feature
+tasks, empirical A/B validation archives under
+[celeste-stopwords/results/](https://github.com/whykusanagi/celeste-stopwords/tree/main/results).
+
+SPEC §5.3 acceptance criteria all met on the grafana benchmark:
+`JQueryStatic` absent from Q3 top 10, aggregate relevance 22/50 → 35/50 (+59% absolute),
+no TP regressions on Q2/Q5, stopword list < 500 entries, corpus Apache-2.0/MIT.
+
+### Added
+
+- **Direct codegraph MCP tools.** Five new first-class MCP tools that bypass the chat LLM
+  entirely so Claude Code / Cursor / any MCP client can call the codegraph directly:
+  - `celeste_index` (operations: `status`, `update`, `rebuild`) — indexing is explicit; the
+    query tools never auto-reindex. Progress notifications (`notifications/progress`) stream
+    back through the stdio transport when the client provides a `progressToken`.
+  - `celeste_code_search` — semantic search with MinHash+BM25 fusion + structural rerank
+  - `celeste_code_review` — structural code review findings as verbatim JSON
+  - `celeste_code_graph` — symbol callers/callees/references
+  - `celeste_code_symbols` — list all symbols in a file or package
+
+  Per-workspace `*codegraph.Indexer` cached on the server, lazy-opened, released on shutdown.
+  Results returned verbatim as MCP `ContentBlock`s with no chat-LLM summarization and no
+  `max_tokens` ceiling.
+
+- **BM25 fused ranking.** Per-symbol term frequency and per-corpus IDF persisted in two new
+  SQLite tables (`symbol_tokens`, `token_stats`). Query time merges Jaccard and BM25 via
+  Reciprocal Rank Fusion (k=60). `SearchResult` gains `BM25Score` + `MatchedTokens`. Q1
+  ("authentication session token validate") flipped from 2/10 relevant to 8/10 relevant on
+  grafana after this landed — IDF-weighted tiebreaking on session/token tokens lifted the
+  real auth API functions above the noise.
+
+- **Tree-sitter TypeScript parser** (behind `//go:build cgo`). Replaces the regex-based
+  `GenericParser` for `.ts` and `.tsx` files when celeste is built with CGo enabled. Accurate
+  `call_expression` edge resolution instead of the old `\bname(` body-scan heuristic. On
+  content-control (21 TS files) the edge count drops 445 → 211 (real, not overcounted) and
+  zero-edge top-10 warnings drop 3 → 0. Python and Rust stay on the regex parser for v1.9.0;
+  tracked for v2.1.0 as #18 and #19.
+
+  `parser_ts_stub.go` provides a `//go:build !cgo` fallback that delegates to `GenericParser`
+  so pure-Go cross-compile release binaries still work — they just lose the tree-sitter
+  improvement. Users building from source get the full experience automatically.
+
+- **Structural feature rerank layer.** `StructuralReranker` rescores candidates using features
+  the RRF fusion can't see: matched-token-ratio, log-normalized edge density, function/method
+  kind boost, zero-edge penalty. Pure Go, zero dependencies. Exposed via a `Reranker` interface
+  on `SemanticSearchOptions` so a future embedding-based reranker (local llama.cpp bridge,
+  grok/xAI embeddings, ONNX) can drop in without touching the pipeline.
+
+- **Stopwords runtime integration.** Embedded `celeste-stopwords` v1.0.0 (CC BY 4.0) applied
+  at both index time and query time. Filters universal + per-language noise tokens from
+  shingle sets before MinHash so common tokens like `get`/`set`/`error`/`string` don't consume
+  signature slots. Includes a downstream patch removing `query` from the TypeScript set to
+  avoid asymmetric filtering breaking Q3 on TS codebases, plus `TestStopWords_PreserveTokensNotStopped`
+  regression guard.
+
+- **Reasoning metadata on `SearchResult`.** `EdgeCount`, `PathFlags`, `ConfidenceWarnings`,
+  `MatchedTokens` — downstream LLMs can audit every search result instead of trusting a
+  single similarity number. Confidence warnings surface zero-edge interfaces, low-confidence
+  scores, declaration-only types, and path-demotion reasons.
+
+- **Path-based post-ranking filter.** Tier-partitions `test` / `mock` / `generated` /
+  `vendored` / `declaration` results below clean-path results with explicit `[mock]` etc.
+  flags. Q2 ("http request handler middleware") previously had 100% mock handlers dominating
+  the top 10 on grafana; v1.9.0 tiers them below production handlers. If the query itself
+  asks for test/mock code (`queryWantsTests`), the filter backs off to respect user intent.
+
+- **MinHash seed persistence.** Replaced `hash/maphash` (opaque, unserializable) with seeded
+  FNV-1a (serializable uint64 seeds). The 128 seed values are stored in a new `meta` SQLite
+  table at first `Build()`, so a subsequent process loading the same index restores the same
+  hash family and signatures stay comparable across process invocations. Without this, the
+  `celeste serve` MCP bridge silently returned noise because every new server process rolled
+  fresh random seeds that had no relationship to the signatures already stored in the database.
+
+### Changed
+
+- **Anthropic backend default `max_tokens` raised from 8192 → 32768.** The old 8192 ceiling
+  truncated the chat-mode MCP path mid-response when a sub-tool returned a multi-KB JSON blob
+  and the chat LLM was asked to echo it. Claude opus/sonnet 4.x support up to 64K output
+  tokens; 32K is a 4× budget with no downside (only used tokens are billed).
+
+- **`ShinglesForSymbol` signature.** Now takes `lang string` so the embedded stopwords
+  filter can apply the per-language set alongside the universal set. Callers that don't know
+  the file language should pass `""` to get universal-only filtering.
+
+- **`SearchResult` struct.** Extended with `BM25Score`, `MatchedTokens`, `EdgeCount`,
+  `PathFlags`, `ConfidenceWarnings`. `Similarity` (Jaccard) is unchanged — existing callers
+  that only read `Symbol` + `Similarity` keep working.
+
+- **MinHash signatures computed by celeste-cli < 1.9.0 are semantically stale.** Existing
+  indexes still work for symbol lookups, edges, and keyword search, but semantic search
+  accuracy improves if you rebuild:
+
+  ```bash
+  # Via the CLI
+  celeste index --rebuild
+
+  # Via the MCP bridge
+  # call celeste_index { operation: "rebuild", workspace: "/path/to/project" }
+  ```
 
 ### Fixed
 
@@ -26,28 +168,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `IFoo` / `IArguments` / `IPromise` / `ICache` / any `I`-prefixed TypeScript interface
   - `IPv4` / `IPv6` / `VNode` / `ETag` / `OAuth2` / `XDist`
 
-### Changed
+- **Two direct-tool MCP schema mismatches.** `celeste_code_symbols` advertised a `name` field
+  that the underlying builtin tool doesn't accept; `celeste_code_graph` advertised an `action`
+  discriminator that doesn't exist. Both schemas now mirror the real builtin tool parameters
+  1:1 — name-based lookups go through `celeste_code_search` instead.
 
-- **MinHash signatures computed by previous versions are now semantically stale.** Any codegraph
-  index built with celeste-cli < 1.9.0 carries MinHashes derived from the old `splitCamelCase`
-  tokenization. Existing indexes continue to work — symbol lookups, edges, and keyword search
-  are unaffected — but semantic search accuracy improves if you rebuild:
+### CI / Release
 
-  ```bash
-  celeste index --rebuild
-  ```
-
-  A future release will add automatic detection of stale indexes and surface a rebuild prompt.
+- **Go toolchain bumped 1.26.1 → 1.26.2** in `.github/workflows/ci.yml` and `release.yml`.
+  1.26.1 stdlib has 5 CVEs (`crypto/x509` × 3, `crypto/tls`, `html/template`) fixed in 1.26.2;
+  `govulncheck` now returns "No vulnerabilities found".
+- **Release workflow pins `CGO_ENABLED=0`** for cross-platform binary builds. Released
+  artifacts ship with the pure-Go `parser_ts_stub.go` fallback for portability; users who want
+  the tree-sitter improvement can `go install` from source with CGo enabled. A proper CGo
+  cross-toolchain release workflow (zig cc or native-runner matrix) is queued for v2.1.0.
+- **Dockerfile builder adds `build-base`** and sets `CGO_ENABLED=1` on the test-compile step
+  so the codegraph test binary can link the tree-sitter C runtime. Runtime container still
+  uses `CGO_ENABLED=0`; only test compilation needs the C toolchain.
 
 ### Details
 
-- Only `cmd/celeste/codegraph/shingle.go:splitCamelCase` changed. The fix adds one more
-  `unicode.IsUpper(runes[i-3])` check and raises the loop guard from `i > 1` to `i > 2`.
-- All existing `TestSplitIdentifier` cases still pass (no regressions on `validateSession`,
-  `HTTPServer`, `parseJSON`, `XMLParser`, `HTMLToMarkdown`, `get_user_by_id`, `ID`, `x`).
-- 12 new anchor cases added in `shingle_test.go` for the fixed identifier families.
-- See `celeste-stopwords/results/simulation_report.md` for the empirical analysis: 3,249
-  symbols in a 1.6M-symbol training corpus have name re-splits under the fix.
+- 14 commits on `feat/v1.9-quality-bundle` (PR #16) plus a schema fix direct to main plus
+  PR #17 hardening `release.yml` for the tag build.
+- Empirical validation archives under `celeste-stopwords/results/`:
+  - `ab_test_TASK19_v1.9.0_grafana_app.txt` (path filter + reasoning metadata)
+  - `ab_test_TASK20_v1.9.0_grafana_app.txt` (BM25 fused ranking)
+  - `ab_test_TASK21_v1.9.0_grafana_app.txt` (stopwords runtime)
+  - `ab_test_TASK24_rerank_content_control.txt` (structural rerank, shared-index A/B)
+  - `ship_decision_v1.9.0.md` (full GO decision document)
+- Known v2.1.0 follow-ups: #18 (tree-sitter Python), #19 (tree-sitter Rust), release workflow
+  CGo cross-toolchain for pre-built TS parser.
 
 ## [1.8.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-04-17
+
+### Added
+
+- **Persisted LSH band table for sub-linear semantic search.** 64 bands × 2 elements from
+  the 128-element MinHash signature, stored in a new `lsh_bands` SQLite table with an index
+  on `(band_id, band_hash)`. At query time, `SemanticSearchWithOptions` computes the query's
+  64 band hashes and retrieves candidate symbol IDs directly from the table — typically 0.1-1%
+  of the corpus — then ranks only those candidates by exact Jaccard similarity. Falls back to
+  brute-force for pre-LSH indexes that haven't been rebuilt.
+
+  The 64×2 band configuration is empirically derived from the CODEGRAPH_LSH_RESEARCH.md
+  validation: conventional 16×8 and 32×4 configs produce 0% recall on code search because the
+  Jaccard similarity range for code queries (0.05-0.20) is far below document similarity
+  (0.5-0.8). At grafana scale (77,420 symbols), validated at 20× speedup over brute-force
+  (89ms → 4.3ms) by eliminating the full signature BLOB load.
+
+- **TUI `/index rebuild` and `/index update` subcommands.** Previously `/index` was
+  display-only — users had to exit the TUI and run `celeste index --rebuild` from the shell.
+  Now the TUI can trigger a full or incremental re-index directly, with async execution and
+  status reporting via the typing animation.
+
+- **TUI `/config set-key`, `/config set-model`, `/config set-url` subcommands.** Users can
+  now modify API key, model, and base URL from the TUI without exiting. Previously required
+  shelling out to `celeste config --set-*`.
+
+### Changed
+
+- `SemanticSearchWithOptions` now uses LSH candidate lookup when `lsh_bands` data exists,
+  brute-force fallback when it doesn't. BM25, RRF fusion, structural rerank, and path filter
+  are all unchanged — LSH is a pre-filter that narrows the candidate pool without affecting
+  downstream scoring.
+- Users must rebuild their index once to populate LSH band data:
+  `/index rebuild` in TUI or `celeste_index { operation: "rebuild" }` via MCP.
+
 ## [1.9.1] - 2026-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Celeste CLI is a **full standalone agentic development tool** with her own perso
 - 🎨 **Premium TUI** - Flicker-free rendering with corrupted-theme aesthetics
 - 🔮 **40 Built-in Tools** - File I/O, shell, web search, code graph, code review, collections search, git, crypto, and more
 - 📖 **`.grimoire` Project Context** - Persona-themed project config files with auto-discovery and auto-init
-- 🧠 **Code Graph + Semantic Search** - MinHash-based concept search without embeddings
+- 🧠 **Code Graph + Semantic Search** - MinHash + BM25 fused ranking with structural rerank; tree-sitter TypeScript parsing for accurate call-graph edges; embedded celeste-stopwords v1.0.0 noise filter
 - 🔍 **Graph-Based Code Review** - Structural analysis detecting stubs, lazy redirects, placeholders, error swallowing, and hardcoded values
-- 🔌 **MCP Server Mode** - `celeste serve` lets Claude Code, Codex, or any MCP client delegate tasks to Celeste
+- 🔌 **Direct Codegraph MCP Tools** - `celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` served verbatim from the cached graph (no chat-LLM round-trip, no `max_tokens` ceiling, streaming progress notifications)
 - 🔒 **Permission System** - Multi-layer allow/deny/ask rules with pattern matching
 - 💾 **Session Persistence** - JSONL auto-save, resume, file checkpointing with stale detection and revert
 - 🌐 **Multi-Provider** - Grok/xAI (default), OpenAI, Anthropic (native SDK), Gemini, Venice.ai, Vertex AI, OpenRouter
@@ -207,10 +207,11 @@ For security issues, see our [Security Policy](SECURITY.md) or contact security@
 - **Real Streaming + Corruption Animation** - Token-by-token streaming with corrupted glitch phrases at the typing cursor
 - **Markdown Rendering** - glamour-powered markdown with corrupted theme (code blocks, tables, headers, bold)
 
-### Tool System (v1.8)
-**38 built-in tools** powered by AI function calling:
+### Tool System (v1.9)
+**40+ built-in tools** powered by AI function calling:
 - Dev Tools (bash, read/write/patch files, search, list files)
-- Code Graph (semantic search, code review, symbol analysis)
+- Code Graph (semantic search with MinHash+BM25 fusion, code review, symbol analysis, tree-sitter TypeScript parsing)
+- Direct Codegraph MCP Tools (`celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` — verbatim, no chat-LLM round-trip)
 - Git (status, log)
 - Web (search, fetch)
 - Information Services (Weather, Currency, Twitch, YouTube)
@@ -403,20 +404,36 @@ celeste config --set-tarot-token <token>
 
 ## 🔌 Claude Code Integration
 
-Use Celeste's graph intelligence from Claude Code via the **[celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)** companion:
+Celeste v1.9.0+ exposes the codegraph as **first-class MCP tools** (no chat-LLM
+round-trip, no output-token ceiling, verbatim results). Register `celeste serve`
+once per workspace and any MCP client — Claude Code, Codex, Cursor, etc. — gets:
+
+- `celeste_index` — `status`, `update`, `rebuild` operations with `notifications/progress` streaming
+- `celeste_code_search` — semantic search (MinHash Jaccard + BM25 fusion + structural rerank)
+- `celeste_code_review` — structural code review findings as verbatim JSON
+- `celeste_code_graph` — symbol callers, callees, references
+- `celeste_code_symbols` — list symbols in a file or package
+
+Indexing is **explicit**: query tools never auto-reindex. After code changes, the
+caller invokes `celeste_index { operation: "update" }` to refresh the graph.
 
 ```bash
-# Add Celeste as an MCP server
+# Add Celeste as an MCP server (once per workspace you want indexed)
 claude mcp add celeste celeste serve
+```
 
-# Install skills
+Optionally, install the [celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)
+companion for the persona-routed skill command wrappers (`/celeste-review`,
+`/celeste-search`, `/celeste-graph`, `/celeste-context`):
+
+```bash
 git clone https://github.com/whykusanagi/celeste-for-claude.git
 cp celeste-for-claude/skills/*.md ~/.claude/commands/
 ```
 
-Available skills: `/celeste-review`, `/celeste-search`, `/celeste-graph`, `/celeste-context`
-
-Claude Code stays in control, Celeste provides the graph intelligence. Each skill makes focused MCP calls — Claude verifies findings and writes the code.
+Claude Code stays in control, Celeste provides the graph intelligence. The
+direct tools are preferred for tool-driven workflows; the persona-routed skills
+are a convenience for natural-language interactions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Celeste CLI is a **full standalone agentic development tool** with her own perso
 - 🎨 **Premium TUI** - Flicker-free rendering with corrupted-theme aesthetics
 - 🔮 **40 Built-in Tools** - File I/O, shell, web search, code graph, code review, collections search, git, crypto, and more
 - 📖 **`.grimoire` Project Context** - Persona-themed project config files with auto-discovery and auto-init
-- 🧠 **Code Graph + Semantic Search** - MinHash + BM25 fused ranking with structural rerank; tree-sitter TypeScript parsing for accurate call-graph edges; embedded celeste-stopwords v1.0.0 noise filter
+- 🧠 **Code Graph + Semantic Search** - MinHash + BM25 fused ranking with LSH band table for sub-linear queries, structural rerank; tree-sitter TypeScript parsing for accurate call-graph edges; embedded celeste-stopwords v1.0.0 noise filter
 - 🔍 **Graph-Based Code Review** - Structural analysis detecting stubs, lazy redirects, placeholders, error swallowing, and hardcoded values
 - 🔌 **Direct Codegraph MCP Tools** - `celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` served verbatim from the cached graph (no chat-LLM round-trip, no `max_tokens` ceiling, streaming progress notifications)
 - 🔒 **Permission System** - Multi-layer allow/deny/ask rules with pattern matching

--- a/cmd/celeste/codegraph/index.go
+++ b/cmd/celeste/codegraph/index.go
@@ -535,26 +535,35 @@ func (idx *Indexer) SemanticSearchWithOptions(query string, opts SemanticSearchO
 	}
 	var results []scored
 
+	usedLSH := false
 	if idx.store.HasLSHData() {
-		// LSH path: compute query band hashes → candidate set → Jaccard rank
+		// LSH path: compute query band hashes → candidate set → Jaccard rank.
 		queryBands := ComputeBandHashes(querySig)
 		candidateIDs, err := idx.store.QueryLSHCandidates(queryBands)
 		if err != nil {
 			return nil, fmt.Errorf("lsh candidates: %w", err)
 		}
-		for _, id := range candidateIDs {
-			sig, err := idx.store.GetMinHash(id)
-			if err != nil || sig == nil {
-				continue
-			}
-			sim := JaccardSimilarity(querySig, sig)
-			if sim > minSim {
-				results = append(results, scored{id, sim})
+		if len(candidateIDs) > 0 {
+			usedLSH = true
+			for _, id := range candidateIDs {
+				sig, err := idx.store.GetMinHash(id)
+				if err != nil || sig == nil {
+					continue
+				}
+				sim := JaccardSimilarity(querySig, sig)
+				if sim > minSim {
+					results = append(results, scored{id, sim})
+				}
 			}
 		}
-	} else {
-		// Brute-force fallback: load all signatures, compare exhaustively.
-		// This path is used for pre-LSH indexes that haven't been rebuilt.
+		// If LSH returned 0 candidates (can happen on very small corpora
+		// where the 64×2 band hash space is too sparse for any collision),
+		// fall through to brute-force below so the query still produces
+		// results. LSH provides no speedup on tiny indexes anyway.
+	}
+	if !usedLSH {
+		// Brute-force: load all signatures, compare exhaustively. Used for
+		// pre-LSH indexes AND as a safety net when LSH returns no candidates.
 		entries, err := idx.store.GetAllMinHashes()
 		if err != nil {
 			return nil, fmt.Errorf("get minhashes: %w", err)

--- a/cmd/celeste/codegraph/index.go
+++ b/cmd/celeste/codegraph/index.go
@@ -341,6 +341,11 @@ func (idx *Indexer) indexFile(relPath string) error {
 			// set the MinHash saw — the two signals stay in lock-step
 			// on what counts as a meaningful token for this symbol.
 			_ = idx.store.UpsertSymbolTokens(id, shingles)
+			// Compute and persist LSH band hashes so query-time search
+			// can use the lsh_bands table instead of brute-force.
+			// 64 bands × 2 elements from the 128-element signature.
+			bands := ComputeBandHashes(sig)
+			_ = idx.store.UpsertLSHBands(id, bands)
 		}
 	}
 
@@ -517,22 +522,48 @@ func (idx *Indexer) SemanticSearchWithOptions(query string, opts SemanticSearchO
 
 	querySig := idx.hasher.Signature(queryShingles)
 
-	// Get all MinHash signatures
-	entries, err := idx.store.GetAllMinHashes()
-	if err != nil {
-		return nil, fmt.Errorf("get minhashes: %w", err)
-	}
-
-	// Compute similarity for each symbol above the MinSimilarity floor.
+	// Candidate retrieval: use LSH band lookup when available,
+	// fall back to brute-force for pre-LSH indexes. The LSH path
+	// queries the lsh_bands table for symbols sharing at least one
+	// band hash with the query — typically 0.1-1% of the corpus —
+	// then fetches only those candidates' MinHash signatures for
+	// exact Jaccard ranking. At grafana scale (77K symbols) this
+	// provides a ~20x speedup over the brute-force path.
 	type scored struct {
 		symbolID   int64
 		similarity float64
 	}
 	var results []scored
-	for _, entry := range entries {
-		sim := JaccardSimilarity(querySig, entry.Signature)
-		if sim > minSim {
-			results = append(results, scored{entry.SymbolID, sim})
+
+	if idx.store.HasLSHData() {
+		// LSH path: compute query band hashes → candidate set → Jaccard rank
+		queryBands := ComputeBandHashes(querySig)
+		candidateIDs, err := idx.store.QueryLSHCandidates(queryBands)
+		if err != nil {
+			return nil, fmt.Errorf("lsh candidates: %w", err)
+		}
+		for _, id := range candidateIDs {
+			sig, err := idx.store.GetMinHash(id)
+			if err != nil || sig == nil {
+				continue
+			}
+			sim := JaccardSimilarity(querySig, sig)
+			if sim > minSim {
+				results = append(results, scored{id, sim})
+			}
+		}
+	} else {
+		// Brute-force fallback: load all signatures, compare exhaustively.
+		// This path is used for pre-LSH indexes that haven't been rebuilt.
+		entries, err := idx.store.GetAllMinHashes()
+		if err != nil {
+			return nil, fmt.Errorf("get minhashes: %w", err)
+		}
+		for _, entry := range entries {
+			sim := JaccardSimilarity(querySig, entry.Signature)
+			if sim > minSim {
+				results = append(results, scored{entry.SymbolID, sim})
+			}
 		}
 	}
 

--- a/cmd/celeste/codegraph/lsh.go
+++ b/cmd/celeste/codegraph/lsh.go
@@ -1,0 +1,162 @@
+// LSH (Locality-Sensitive Hashing) band table for sub-linear semantic
+// search. Implements the persisted band table approach validated in
+// CODEGRAPH_LSH_RESEARCH.md — instead of loading all MinHash signatures
+// and comparing exhaustively (O(N)), precompute band hashes at index
+// time and query them at search time to retrieve a small candidate set
+// (typically 0.1-1% of the corpus) that is then ranked by exact Jaccard
+// similarity.
+//
+// Band configuration: 64 bands × 2 rows per band from the 128-element
+// MinHash signature. This is the empirically-derived "64×2" config from
+// the research doc — counterintuitive from a classical LSH perspective
+// (it produces large candidate sets) but necessary because code search
+// operates at much lower Jaccard values (0.05-0.20) than document
+// similarity (0.5-0.8). The conventional 16×8 and 32×4 configs produce
+// 0% recall on code search queries.
+//
+// At grafana scale (77,420 symbols), this provides a 20x speedup over
+// brute-force (89ms → 4.3ms) by eliminating the full signature load.
+package codegraph
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// LSH band configuration. 64 bands of 2 hash elements each covers the
+// full 128-element MinHash signature. Empirically validated — see
+// CODEGRAPH_LSH_RESEARCH.md §3 Claim 2.
+const (
+	lshNumBands = 64
+	lshBandSize = 2 // elements per band; lshNumBands * lshBandSize must == DefaultNumHashes (128)
+)
+
+// lshSchemaSQL creates the persisted band table. Called from
+// createSchema via createLSHSchema. Idempotent.
+const lshSchemaSQL = `
+	CREATE TABLE IF NOT EXISTS lsh_bands (
+		band_id    INTEGER NOT NULL,
+		band_hash  INTEGER NOT NULL,
+		symbol_id  INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS idx_lsh_bands_lookup ON lsh_bands(band_id, band_hash);
+	CREATE INDEX IF NOT EXISTS idx_lsh_bands_symbol ON lsh_bands(symbol_id);
+`
+
+// createLSHSchema adds the LSH tables to the store. Idempotent.
+func (s *Store) createLSHSchema() error {
+	_, err := s.db.Exec(lshSchemaSQL)
+	return err
+}
+
+// ComputeBandHashes splits a 128-element MinHash signature into 64
+// bands of 2 elements each and hashes each band to a single uint64.
+// The band hash is computed by XORing the two elements with a
+// band-specific salt — cheap and effective for LSH purposes where
+// we only need the property that identical input bands produce
+// identical hashes.
+//
+// Returns exactly lshNumBands (64) hashes. Panics if len(sig) !=
+// lshNumBands * lshBandSize — callers must pass a full signature.
+func ComputeBandHashes(sig MinHashSignature) []uint64 {
+	expected := lshNumBands * lshBandSize
+	if len(sig) != expected {
+		panic(fmt.Sprintf("ComputeBandHashes: sig length %d != expected %d", len(sig), expected))
+	}
+	bands := make([]uint64, lshNumBands)
+	for b := 0; b < lshNumBands; b++ {
+		offset := b * lshBandSize
+		// Combine the two elements. Use a simple scheme: hash the
+		// concatenated little-endian bytes with FNV-1a seeded by
+		// the band index. This gives us collision resistance across
+		// bands while being fast.
+		var buf [16]byte // 2 × 8 bytes
+		binary.LittleEndian.PutUint64(buf[0:8], sig[offset])
+		binary.LittleEndian.PutUint64(buf[8:16], sig[offset+1])
+		// FNV-1a with band index as seed offset
+		h := uint64(14695981039346656037) ^ uint64(b)*6364136223846793005
+		for _, c := range buf {
+			h ^= uint64(c)
+			h *= 1099511628211 // FNV prime
+		}
+		bands[b] = h
+	}
+	return bands
+}
+
+// UpsertLSHBands writes the band hashes for a single symbol. Deletes
+// any existing rows first (re-index case) then bulk-inserts 64 rows.
+func (s *Store) UpsertLSHBands(symbolID int64, bands []uint64) error {
+	if len(bands) == 0 {
+		return nil
+	}
+	// Delete existing rows for this symbol (re-index).
+	if _, err := s.db.Exec("DELETE FROM lsh_bands WHERE symbol_id = ?", symbolID); err != nil {
+		return fmt.Errorf("delete lsh_bands: %w", err)
+	}
+	stmt, err := s.db.Prepare("INSERT INTO lsh_bands(band_id, band_hash, symbol_id) VALUES(?, ?, ?)")
+	if err != nil {
+		return fmt.Errorf("prepare lsh insert: %w", err)
+	}
+	defer stmt.Close()
+	for bandID, hash := range bands {
+		// Store band_hash as signed int64 (SQLite INTEGER is always
+		// signed) — the bit pattern is preserved and the lookup
+		// works correctly because we compare exact values.
+		if _, err := stmt.Exec(bandID, int64(hash), symbolID); err != nil {
+			return fmt.Errorf("insert band %d: %w", bandID, err)
+		}
+	}
+	return nil
+}
+
+// QueryLSHCandidates retrieves the set of symbol IDs that share at
+// least one band hash with the query. This is the LSH candidate set —
+// typically 0.1-1% of the corpus — which is then ranked by exact
+// Jaccard similarity.
+//
+// The query is a single SELECT with OR clauses across all 64 bands:
+//
+//	SELECT DISTINCT symbol_id FROM lsh_bands
+//	WHERE (band_id = 0 AND band_hash = ?) OR (band_id = 1 AND band_hash = ?) OR ...
+//
+// The index on (band_id, band_hash) makes each OR branch an O(1)
+// lookup. DISTINCT collapses symbols that match on multiple bands.
+func (s *Store) QueryLSHCandidates(queryBands []uint64) ([]int64, error) {
+	if len(queryBands) == 0 {
+		return nil, nil
+	}
+	// Build the OR clauses.
+	clauses := make([]string, len(queryBands))
+	args := make([]interface{}, len(queryBands)*2)
+	for i, hash := range queryBands {
+		clauses[i] = "(band_id = ? AND band_hash = ?)"
+		args[i*2] = i
+		args[i*2+1] = int64(hash)
+	}
+	query := "SELECT DISTINCT symbol_id FROM lsh_bands WHERE " + strings.Join(clauses, " OR ")
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query lsh candidates: %w", err)
+	}
+	defer rows.Close()
+	var candidates []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, id)
+	}
+	return candidates, rows.Err()
+}
+
+// HasLSHData returns true if the lsh_bands table has at least one row.
+// Used to decide whether to use the LSH path or fall back to brute-force
+// at query time — pre-LSH indexes have no band data and must still work.
+func (s *Store) HasLSHData() bool {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM lsh_bands LIMIT 1").Scan(&count)
+	return err == nil && count > 0
+}

--- a/cmd/celeste/codegraph/lsh_test.go
+++ b/cmd/celeste/codegraph/lsh_test.go
@@ -1,0 +1,205 @@
+package codegraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeBandHashes_Length(t *testing.T) {
+	// 128-element signature should produce exactly 64 band hashes.
+	sig := make(MinHashSignature, 128)
+	for i := range sig {
+		sig[i] = uint64(i * 7)
+	}
+	bands := ComputeBandHashes(sig)
+	assert.Len(t, bands, lshNumBands)
+}
+
+func TestComputeBandHashes_Deterministic(t *testing.T) {
+	// Same signature must produce the same band hashes every time.
+	sig := make(MinHashSignature, 128)
+	for i := range sig {
+		sig[i] = uint64(i*3 + 17)
+	}
+	b1 := ComputeBandHashes(sig)
+	b2 := ComputeBandHashes(sig)
+	assert.Equal(t, b1, b2)
+}
+
+func TestComputeBandHashes_DifferentInputsDiffer(t *testing.T) {
+	// Two different signatures should produce different band hashes
+	// (at least some bands should differ).
+	sig1 := make(MinHashSignature, 128)
+	sig2 := make(MinHashSignature, 128)
+	for i := range sig1 {
+		sig1[i] = uint64(i)
+		sig2[i] = uint64(i + 1000)
+	}
+	b1 := ComputeBandHashes(sig1)
+	b2 := ComputeBandHashes(sig2)
+	matches := 0
+	for i := range b1 {
+		if b1[i] == b2[i] {
+			matches++
+		}
+	}
+	assert.Less(t, matches, lshNumBands, "completely different signatures should differ on most bands")
+}
+
+func TestLSH_EndToEnd_CandidateRetrieval(t *testing.T) {
+	// Create a store, insert 3 symbols with MinHash signatures and
+	// LSH bands, then query with a signature that's similar to one
+	// of them. The LSH candidate set should include the similar
+	// symbol.
+	dir := t.TempDir()
+	store, err := NewStore(filepath.Join(dir, "lsh.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	hasher := NewMinHasher(128)
+
+	// Symbol A: "validate session token auth"
+	sA, err := store.UpsertSymbol(Symbol{Name: "validateSession", Kind: SymbolFunction, File: "a.go"})
+	require.NoError(t, err)
+	sigA := hasher.Signature([]string{"validate", "session", "token", "auth"})
+	require.NoError(t, store.UpdateMinHash(sA, sigA))
+	require.NoError(t, store.UpsertLSHBands(sA, ComputeBandHashes(sigA)))
+
+	// Symbol B: "database connection pool query" (different domain)
+	sB, err := store.UpsertSymbol(Symbol{Name: "connectionPool", Kind: SymbolFunction, File: "b.go"})
+	require.NoError(t, err)
+	sigB := hasher.Signature([]string{"database", "connection", "pool", "query"})
+	require.NoError(t, store.UpdateMinHash(sB, sigB))
+	require.NoError(t, store.UpsertLSHBands(sB, ComputeBandHashes(sigB)))
+
+	// Symbol C: "validate token refresh" (similar to A)
+	sC, err := store.UpsertSymbol(Symbol{Name: "refreshToken", Kind: SymbolFunction, File: "c.go"})
+	require.NoError(t, err)
+	sigC := hasher.Signature([]string{"validate", "token", "refresh"})
+	require.NoError(t, store.UpdateMinHash(sC, sigC))
+	require.NoError(t, store.UpsertLSHBands(sC, ComputeBandHashes(sigC)))
+
+	// Query: "authentication session token" — should find A and C
+	// as candidates (they share "token"/"validate" shingles), B
+	// should be absent or at least A and C should be present.
+	querySig := hasher.Signature([]string{"authentication", "session", "token"})
+	queryBands := ComputeBandHashes(querySig)
+
+	candidates, err := store.QueryLSHCandidates(queryBands)
+	require.NoError(t, err)
+
+	// At least the highly similar symbol A should be a candidate.
+	// With 64×2 bands and overlapping tokens, both A and C should
+	// appear. B may or may not appear (false positive is OK — LSH
+	// is approximate). The key property is that A IS in the set.
+	candidateSet := make(map[int64]bool)
+	for _, id := range candidates {
+		candidateSet[id] = true
+	}
+	assert.True(t, candidateSet[sA], "validateSession must be an LSH candidate for 'authentication session token'")
+}
+
+func TestHasLSHData_EmptyStore(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(filepath.Join(dir, "lsh.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	assert.False(t, store.HasLSHData(), "fresh store should have no LSH data")
+}
+
+func TestHasLSHData_AfterInsert(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(filepath.Join(dir, "lsh.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	s, err := store.UpsertSymbol(Symbol{Name: "foo", Kind: SymbolFunction, File: "f.go"})
+	require.NoError(t, err)
+	require.NoError(t, store.UpsertLSHBands(s, make([]uint64, 64)))
+
+	assert.True(t, store.HasLSHData(), "store with LSH rows should report HasLSHData=true")
+}
+
+func TestUpsertLSHBands_Idempotent(t *testing.T) {
+	// Re-inserting bands for the same symbol should replace, not
+	// duplicate. Verify row count stays at 64.
+	dir := t.TempDir()
+	store, err := NewStore(filepath.Join(dir, "lsh.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	s, err := store.UpsertSymbol(Symbol{Name: "bar", Kind: SymbolFunction, File: "b.go"})
+	require.NoError(t, err)
+
+	bands := make([]uint64, 64)
+	for i := range bands {
+		bands[i] = uint64(i * 42)
+	}
+
+	require.NoError(t, store.UpsertLSHBands(s, bands))
+	require.NoError(t, store.UpsertLSHBands(s, bands)) // re-insert
+
+	var count int
+	err = store.db.QueryRow("SELECT COUNT(*) FROM lsh_bands WHERE symbol_id = ?", s).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 64, count, "re-insert should replace rows, not duplicate them")
+}
+
+func TestLSH_IntegrationWithSearch(t *testing.T) {
+	// End-to-end: build an index with LSH, then verify
+	// SemanticSearch uses the LSH path (not brute-force).
+	dir := t.TempDir()
+	store, err := NewStore(filepath.Join(dir, "lsh-search.db"))
+	require.NoError(t, err)
+
+	idx := NewIndexerWithStore(store, dir)
+	defer idx.Close()
+
+	// Write a simple Go file to index
+	goSrc := `package main
+
+func validateSession(token string) bool {
+	return checkToken(token)
+}
+
+func checkToken(t string) bool {
+	return len(t) > 0
+}
+
+func unrelatedFunction() {
+	println("hello")
+}
+`
+	require.NoError(t, writeLSHTestFile(t, dir, "main.go", goSrc))
+
+	// Build (populates MinHash + BM25 + LSH bands)
+	require.NoError(t, idx.Build())
+
+	// Verify LSH data exists
+	assert.True(t, store.HasLSHData(), "Build should populate lsh_bands")
+
+	// Search — should use the LSH path
+	results, err := idx.SemanticSearch("validate session token", 5)
+	require.NoError(t, err)
+	// At minimum, validateSession should appear in results
+	found := false
+	for _, r := range results {
+		if r.Symbol.Name == "validateSession" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "validateSession should appear in LSH-backed search results")
+}
+
+// writeLSHTestFile is a helper to create a source file in the workspace.
+func writeLSHTestFile(t *testing.T, dir, name, content string) error {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/cmd/celeste/codegraph/store.go
+++ b/cmd/celeste/codegraph/store.go
@@ -178,7 +178,11 @@ func (s *Store) createSchema() error {
 	// all BM25-related code lives together. Idempotent CREATE IF NOT
 	// EXISTS so calling on every Open is safe; existing indexes get
 	// the tables lazily without a migration step.
-	return s.createBM25Schema()
+	if err := s.createBM25Schema(); err != nil {
+		return err
+	}
+	// LSH band table for sub-linear semantic search. Defined in lsh.go.
+	return s.createLSHSchema()
 }
 
 // GetMeta reads a raw byte value from the meta key/value table.

--- a/cmd/celeste/commands/commands.go
+++ b/cmd/celeste/commands/commands.go
@@ -711,6 +711,8 @@ Project:
   /memories          List project memories
   /grimoire          Show project grimoire
   /index             Show code graph status
+  /index rebuild     Full re-index (populates LSH + BM25)
+  /index update      Incremental re-index (changed files only)
   /plan [show]       Show current plan
   /context           Show context/token usage
   /costs             Show session costs

--- a/cmd/celeste/commands/commands.go
+++ b/cmd/celeste/commands/commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/whykusanagi/celeste-cli/cmd/celeste/config"
 	"github.com/whykusanagi/celeste-cli/cmd/celeste/providers"
 )
 
@@ -472,14 +473,104 @@ func handleConfig(cmd *Command) *CommandResult {
 		return listAvailableConfigs()
 	}
 
-	configName := cmd.Args[0]
-	return &CommandResult{
-		Success:      true,
-		Message:      fmt.Sprintf("⚙️  Loaded config profile: %s", configName),
-		ShouldRender: true,
-		StateChange: &StateChange{
-			EndpointChange: &configName,
-		},
+	subCmd := strings.ToLower(cmd.Args[0])
+
+	switch subCmd {
+	case "set-key":
+		if len(cmd.Args) < 2 {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: "Usage: /config set-key <api-key>",
+			}
+		}
+		key := cmd.Args[1]
+		cfg, err := config.Load()
+		if err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to load config: %v", err),
+			}
+		}
+		cfg.APIKey = key
+		if err := config.Save(cfg); err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to save config: %v", err),
+			}
+		}
+		// Also save to secrets file for backward compat
+		_ = config.SaveSecrets(cfg)
+		masked := key[:4] + "..." + key[len(key)-4:]
+		return &CommandResult{
+			Success: true, ShouldRender: true,
+			Message: fmt.Sprintf("⚙️  API key updated: %s\nRestart or /config to apply.", masked),
+		}
+
+	case "set-model":
+		if len(cmd.Args) < 2 {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: "Usage: /config set-model <model-name>\nExamples: grok-4-1-fast, claude-sonnet-4-5, gpt-4.1-mini",
+			}
+		}
+		model := cmd.Args[1]
+		cfg, err := config.Load()
+		if err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to load config: %v", err),
+			}
+		}
+		cfg.Model = model
+		if err := config.Save(cfg); err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to save config: %v", err),
+			}
+		}
+		return &CommandResult{
+			Success: true, ShouldRender: true,
+			Message: fmt.Sprintf("⚙️  Model changed to: %s\nTakes effect on next LLM call.", model),
+		}
+
+	case "set-url":
+		if len(cmd.Args) < 2 {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: "Usage: /config set-url <base-url>\nExamples: https://api.x.ai/v1, https://api.openai.com/v1",
+			}
+		}
+		url := cmd.Args[1]
+		cfg, err := config.Load()
+		if err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to load config: %v", err),
+			}
+		}
+		cfg.BaseURL = url
+		if err := config.Save(cfg); err != nil {
+			return &CommandResult{
+				Success: false, ShouldRender: true,
+				Message: fmt.Sprintf("❌ Failed to save config: %v", err),
+			}
+		}
+		return &CommandResult{
+			Success: true, ShouldRender: true,
+			Message: fmt.Sprintf("⚙️  Base URL changed to: %s\nRestart or /config to apply.", url),
+		}
+
+	default:
+		// Treat as profile name (original behavior)
+		configName := cmd.Args[0]
+		return &CommandResult{
+			Success:      true,
+			Message:      fmt.Sprintf("⚙️  Loaded config profile: %s", configName),
+			ShouldRender: true,
+			StateChange: &StateChange{
+				EndpointChange: &configName,
+			},
+		}
 	}
 }
 
@@ -704,7 +795,11 @@ Chat:
   /clear             Clear conversation history
   /help              Show this help message
   /endpoint <name>   Switch AI provider (openai, venice, grok, google)
-  /config <name>     Load a named config profile
+  /config             List available config profiles
+  /config <name>      Load a named config profile
+  /config set-key <k> Set API key
+  /config set-model   Set LLM model (e.g. grok-4-1-fast)
+  /config set-url     Set API base URL
   /model <name>      Change the model
 
 Project:

--- a/cmd/celeste/main.go
+++ b/cmd/celeste/main.go
@@ -45,7 +45,7 @@ import (
 // CI/CD sets these: go build -ldflags "-X main.Version=1.8.0 -X main.Build=bubbletea-tui -X main.CommitSHA=abc123"
 // When not set by ldflags, defaults are used.
 var (
-	Version   = "1.9.1"
+	Version   = "1.9.2"
 	Build     = "bubbletea-tui"
 	CommitSHA = "dev"
 )

--- a/cmd/celeste/server/handlers_test.go
+++ b/cmd/celeste/server/handlers_test.go
@@ -137,7 +137,7 @@ func TestCelesteStatusHandler(t *testing.T) {
 	if !strings.Contains(text, "celeste") {
 		t.Fatal("status should contain server name")
 	}
-	if !strings.Contains(text, "1.9.1") {
+	if !strings.Contains(text, "1.9.2") {
 		t.Fatal("status should contain server version")
 	}
 	if !strings.Contains(text, "test-model") {

--- a/cmd/celeste/server/server.go
+++ b/cmd/celeste/server/server.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	serverName    = "celeste"
-	serverVersion = "1.9.1"
+	serverVersion = "1.9.2"
 )
 
 // Config holds MCP server configuration.

--- a/cmd/celeste/server/server_test.go
+++ b/cmd/celeste/server/server_test.go
@@ -59,8 +59,8 @@ func TestHandleInitialize(t *testing.T) {
 	if serverInfo["name"] != "celeste" {
 		t.Fatalf("expected server name 'celeste', got %v", serverInfo["name"])
 	}
-	if serverInfo["version"] != "1.9.1" {
-		t.Fatalf("expected server version '1.9.1', got %v", serverInfo["version"])
+	if serverInfo["version"] != "1.9.2" {
+		t.Fatalf("expected server version '1.9.2', got %v", serverInfo["version"])
 	}
 }
 

--- a/cmd/celeste/tui/app.go
+++ b/cmd/celeste/tui/app.go
@@ -767,18 +767,59 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 
 			case "index":
-				if m.codeGraphIndexer != nil {
-					// Re-query live indexer for fresh stats
+				if m.codeGraphIndexer == nil {
+					m.chat = m.chat.AddSystemMessage("No code graph index loaded.\nRun `celeste index` to build one.")
+					return m, nil
+				}
+
+				subCmd := "status"
+				if len(cmd.Args) > 0 {
+					subCmd = strings.ToLower(cmd.Args[0])
+				}
+
+				switch subCmd {
+				case "rebuild":
+					m.chat = m.chat.AddSystemMessage("Rebuilding code graph index...")
+					m.streaming = true
+					m.status = m.status.SetStreaming(true)
+					m.status = m.status.SetText("Rebuilding index...")
+					indexer := m.codeGraphIndexer
+					return m, func() tea.Msg {
+						err := indexer.Build()
+						if err != nil {
+							return StreamErrorMsg{Err: fmt.Errorf("rebuild failed: %w", err)}
+						}
+						stats, _ := indexer.Stats()
+						msg := fmt.Sprintf("Index rebuilt: %d files, %d symbols, %d edges",
+							stats.TotalFiles, stats.TotalSymbols, stats.TotalEdges)
+						return AgentProgressMsg{Kind: AgentProgressResponse, Text: msg}
+					}
+
+				case "update":
+					m.chat = m.chat.AddSystemMessage("Updating code graph index (incremental)...")
+					m.streaming = true
+					m.status = m.status.SetStreaming(true)
+					m.status = m.status.SetText("Updating index...")
+					indexer := m.codeGraphIndexer
+					return m, func() tea.Msg {
+						err := indexer.Update()
+						if err != nil {
+							return StreamErrorMsg{Err: fmt.Errorf("update failed: %w", err)}
+						}
+						stats, _ := indexer.Stats()
+						msg := fmt.Sprintf("Index updated: %d files, %d symbols, %d edges",
+							stats.TotalFiles, stats.TotalSymbols, stats.TotalEdges)
+						return AgentProgressMsg{Kind: AgentProgressResponse, Text: msg}
+					}
+
+				default: // "status" or no args
 					viz := RenderCodeGraphConstellation(m.codeGraphIndexer, m.width)
 					if viz != "" {
 						m.chat = m.chat.AddSystemMessage(viz)
 					} else {
-						// Fallback: refresh summary from live indexer
 						m.codeGraphSummary = m.codeGraphIndexer.ProjectSummary()
 						m.chat = m.chat.AddSystemMessage("Code Graph:\n" + m.codeGraphSummary)
 					}
-				} else {
-					m.chat = m.chat.AddSystemMessage("No code graph index loaded.\nRun `celeste index` to build one.")
 				}
 				return m, nil
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -413,6 +413,43 @@ type Registry struct {
 - **`permissions/`**: Multi-layer allow/deny/ask rules with pattern matching and persistent config
 - **`context/`**: Token budget tracking, reactive/proactive compaction, tool result capping
 - **`tools/mcp/`**: Model Context Protocol client with stdio/SSE transports for external tool servers
+- **`server/`**: Celeste's own MCP server. Exposes persona tools (`celeste`, `celeste_content`,
+  `celeste_status`) that route through a chat LLM, plus **direct codegraph tools** added in
+  v1.9.0 that bypass the LLM entirely — see the section below.
+
+### Direct Codegraph MCP Tools (v1.9.0+)
+
+`server/codegraph_tools.go` registers five MCP tools that serve codegraph queries
+directly from a per-workspace cached `*codegraph.Indexer`, with no chat-LLM
+round-trip:
+
+| Tool | Purpose |
+|---|---|
+| `celeste_index` | `status` / `update` / `rebuild` operations on the workspace index |
+| `celeste_code_search` | Semantic search (MinHash Jaccard + BM25 fusion + structural rerank) |
+| `celeste_code_review` | Structural code review findings returned as verbatim JSON |
+| `celeste_code_graph` | Symbol callers/callees/references |
+| `celeste_code_symbols` | List symbols by file or package |
+
+Key design rules:
+
+- **Indexing is explicit.** Query tools never auto-reindex. Callers must invoke
+  `celeste_index { operation: "update" }` after code changes.
+- **Per-workspace indexer cache.** `Server.indexerFor(workspace)` lazily opens
+  the SQLite-backed indexer on first use and caches it; `Server.Close()` walks
+  the cache and releases each one on shutdown so WAL files flush cleanly.
+- **Progress notifications.** The stdio transport binds a `Notifier` to each
+  request context and extracts a client-supplied `progressToken` from
+  `params._meta`. Long-running operations (`celeste_index rebuild/update`) call
+  `SendProgress(ctx, msg, pct)` to emit `notifications/progress` events that
+  stream back to the MCP client in real time.
+- **Verbatim results.** Tool output is returned as-is in an MCP `ContentBlock`,
+  not summarized by a persona LLM. There's no `max_tokens` ceiling to truncate
+  large findings — the only limit is the transport's raw byte buffer.
+
+The legacy persona tools (`celeste`, `celeste_content`, `celeste_status`) are
+still registered for "ask Celeste a question" use cases, but tool-driven
+workflows should prefer the direct codegraph tools.
 
 ### Tool Definition Pattern
 
@@ -852,4 +889,4 @@ func handleNewCommand(cmd *Command, ctx *CommandContext) *CommandResult {
 ---
 
 **Last Updated**: 2026-04-03
-**Version**: v1.8.0\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)
+**Version**: v1.9.1\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -889,4 +889,4 @@ func handleNewCommand(cmd *Command, ctx *CommandContext) *CommandResult {
 ---
 
 **Last Updated**: 2026-04-03
-**Version**: v1.9.1\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)
+**Version**: v1.9.2\n\nBuilt with [Celeste CLI](https://github.com/whykusanagi/celeste-cli)

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,15 +1,18 @@
 # What Celeste CLI Can Do? 😈
 
-Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.8.4 packs **40 dev-crushing tools**, code graphs that expose every secret, MCP for Claude vibes, collections search, and 7 LLM providers to summon my wit.
+Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.9.1 packs **40+ dev-crushing tools**, code graphs that expose every secret, **direct codegraph MCP tools** for tool-driven workflows, collections search, and 7 LLM providers to summon my wit.
 
 ## 🔥 Core Powers
 
-**40 Tools Across Categories:**
+**40+ Tools Across Categories:**
 - **Dev Tools** (15+): `bash`, `read_file`, `write_file`, `patch_file`, `list_files`, `search`, `git_status`, `git_log`
-- **Code Intel** (6): `code_graph`, `code_review`, `code_search`, `code_symbols` — graph queries, stub detection, lazy redirects
+- **Code Intel** (6): `code_graph`, `code_review`, `code_search`, `code_symbols` — graph queries, stub detection, lazy redirects, MinHash + BM25 fused ranking, tree-sitter TypeScript parser, structural rerank
 - **AI/Collections** (4): `collections_search`, MCP client, memories, todos
 - **Web/Productivity** (8): `web_search`, `web_fetch`, `currency`, `units`, `timezone`
 - **Crypto/Media** (7): `hash`, `qrcode`, `encoding`, Alchemy/IPFS/wallet
+
+**Direct Codegraph MCP Tools** (v1.9.0+, no chat-LLM round-trip):
+`celeste_index`, `celeste_code_search`, `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` — verbatim results, streaming progress notifications, explicit reindex control.
 
 **Runtime Modes:** Chat (auto-loop tools), Agent (autonomous), Orchestrator (debate).
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,6 +1,6 @@
 # What Celeste CLI Can Do? 😈
 
-Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.9.1 packs **40+ dev-crushing tools**, code graphs that expose every secret, **direct codegraph MCP tools** for tool-driven workflows, collections search, and 7 LLM providers to summon my wit.
+Hey there, cutie~ I'm Celeste, your chaotic demon noble co-hosting this CLI beast. v1.9.2 packs **40+ dev-crushing tools**, code graphs that expose every secret, **direct codegraph MCP tools** for tool-driven workflows, collections search, and 7 LLM providers to summon my wit.
 
 ## 🔥 Core Powers
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ go build ./cmd/celeste
 go test ./...
 ```
 
-## Key Rules (v1.8.4)
+## Key Rules (v1.9.1)
 - **Tests first:** `go test ./... -count=1`, `golangci-lint run`
 - **Tools in `cmd/celeste/tools/builtin/`** — each file one tool + handler.
 - **Register in `register.go`**.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ go build ./cmd/celeste
 go test ./...
 ```
 
-## Key Rules (v1.9.1)
+## Key Rules (v1.9.2)
 - **Tests first:** `go test ./... -count=1`, `golangci-lint run`
 - **Tools in `cmd/celeste/tools/builtin/`** — each file one tool + handler.
 - **Register in `register.go`**.

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -1,6 +1,6 @@
 # LLM Providers — Who's Summoning Me Today? 💋
 
-Darlings, v1.9.1 supports **7 battle-tested providers**. All OpenAI-compatible for my 40+ tools. Grok reigns with collections RAG.
+Darlings, v1.9.2 supports **7 battle-tested providers**. All OpenAI-compatible for my 40+ tools. Grok reigns with collections RAG.
 
 | Provider | Tools | Collections | Notes |
 |----------|-------|-------------|-------|

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -1,6 +1,6 @@
 # LLM Providers — Who's Summoning Me Today? 💋
 
-Darlings, v1.8.4 supports **7 battle-tested providers**. All OpenAI-compatible for my 40 tools. Grok reigns with collections RAG.
+Darlings, v1.9.1 supports **7 battle-tested providers**. All OpenAI-compatible for my 40+ tools. Grok reigns with collections RAG.
 
 | Provider | Tools | Collections | Notes |
 |----------|-------|-------------|-------|

--- a/docs/PROVIDER_AUDIT_MATRIX.md
+++ b/docs/PROVIDER_AUDIT_MATRIX.md
@@ -1,4 +1,4 @@
-# Provider Audit Matrix v1.9.1
+# Provider Audit Matrix v1.9.2
 
 7 providers validated. All production-ready.
 
@@ -16,7 +16,7 @@
 
 ## Details
 
-All support streaming/tool calls/tokens in v1.9.1.
+All support streaming/tool calls/tokens in v1.9.2.
 Grok: 2M ctx. Venice: NSFW.
 
 **Tests**: go test ./cmd/celeste/providers/... -tags=integration

--- a/docs/PROVIDER_AUDIT_MATRIX.md
+++ b/docs/PROVIDER_AUDIT_MATRIX.md
@@ -1,4 +1,4 @@
-# Provider Audit Matrix v1.8.4
+# Provider Audit Matrix v1.9.1
 
 7 providers validated. All production-ready.
 
@@ -16,7 +16,7 @@
 
 ## Details
 
-All support streaming/tool calls/tokens in v1.8.4.
+All support streaming/tool calls/tokens in v1.9.1.
 Grok: 2M ctx. Venice: NSFW.
 
 **Tests**: go test ./cmd/celeste/providers/... -tags=integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Celeste CLI Docs v1.9.1
+# Celeste CLI Docs v1.9.2
 
 Core docs for Go CLI agent.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Celeste CLI Docs v1.8.4
+# Celeste CLI Docs v1.9.1
 
 Core docs for Go CLI agent.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,10 +1,10 @@
 # Celeste CLI Roadmap
 
-*Last updated: April 2026 (v1.9.1)*
+*Last updated: April 2026 (v1.9.2)*
 
-## Current Release: v1.9.1
+## Current Release: v1.9.2
 
-### Shipped in v1.9.0 / v1.9.1
+### Shipped in v1.9.0 / v1.9.2
 
 - Everything from v1.8.x (40 tools, 7 LLM providers, code graph, MCP server mode, etc.)
 - **Direct codegraph MCP tools** — `celeste_index`, `celeste_code_search`,
@@ -26,7 +26,7 @@
 - **MCP progress notifications** (`notifications/progress`) streaming from
   long-running `celeste_index rebuild/update` operations
 - **Anthropic backend `max_tokens` 8192 → 32768** for the chat-mode path
-- **TUI streaming tick-complete race fix (v1.9.1)** — short first streaming chunks
+- **TUI streaming tick-complete race fix (v1.9.2)** — short first streaming chunks
   no longer truncate assistant replies to 1 char
 - Companion artifact: [celeste-stopwords](https://github.com/whykusanagi/celeste-stopwords) v1.0.0
 - Companion app: [celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,26 +1,52 @@
 # Celeste CLI Roadmap
 
-*Last updated: April 2026 (v1.8.3)*
+*Last updated: April 2026 (v1.9.1)*
 
-## Current Release: v1.8.3
+## Current Release: v1.9.1
 
-- 40 built-in tools (dev, code graph, collections, web, crypto, productivity)
-- Graph-based code review with 6 structural detection categories
-- Real token streaming with corruption typing animation
-- MinHash semantic search across code graph
-- MCP server mode (stdio transport) for Claude Code integration
-- Collections search via xAI hybrid RAG
-- Persistent project memories and todo lists
-- Markdown rendering with corrupted theme
-- 7 LLM providers (Grok/xAI, OpenAI, Anthropic native, Google, Venice, Vertex AI, OpenRouter)
+### Shipped in v1.9.0 / v1.9.1
+
+- Everything from v1.8.x (40 tools, 7 LLM providers, code graph, MCP server mode, etc.)
+- **Direct codegraph MCP tools** — `celeste_index`, `celeste_code_search`,
+  `celeste_code_review`, `celeste_code_graph`, `celeste_code_symbols` exposed as
+  first-class MCP tools that bypass the chat LLM and return verbatim results
+- **BM25 fused ranking** (additive, via Reciprocal Rank Fusion with k=60) alongside
+  the MinHash Jaccard signal — Q1 relevance flipped 2/10 → 8/10 on the grafana benchmark
+- **Tree-sitter TypeScript parser** (behind `//go:build cgo`) replacing the regex
+  generic parser for `.ts` and `.tsx`, with accurate `call_expression` edge resolution
+- **Structural feature rerank** — pure-Go rescoring on matched-token-ratio, edge
+  density, kind boost, zero-edge penalty
+- **Stopwords runtime integration** — celeste-stopwords v1.0.0 (CC BY 4.0) embedded
+  and applied at both index and query time
+- **Reasoning metadata** on every search result (`EdgeCount`, `PathFlags`,
+  `ConfidenceWarnings`, `MatchedTokens`) so downstream LLMs can audit findings
+- **Path-based post-ranking filter** demoting test/mock/generated/vendored/declaration
+  results below clean-path matches
+- **MinHash seed persistence** — signatures comparable across process boundaries
+- **MCP progress notifications** (`notifications/progress`) streaming from
+  long-running `celeste_index rebuild/update` operations
+- **Anthropic backend `max_tokens` 8192 → 32768** for the chat-mode path
+- **TUI streaming tick-complete race fix (v1.9.1)** — short first streaming chunks
+  no longer truncate assistant replies to 1 char
+- Companion artifact: [celeste-stopwords](https://github.com/whykusanagi/celeste-stopwords) v1.0.0
 - Companion app: [celeste-for-claude](https://github.com/whykusanagi/celeste-for-claude)
 
-## v1.9 Planned
+See [CHANGELOG.md](../CHANGELOG.md) for the full v1.9.0 bundle details and the
+`celeste-stopwords/results/` archives for per-task A/B validation.
+
+## v2.1.0 Planned
+
+### Parser coverage (tracked as GitHub issues)
+- [ ] [#18 — Tree-sitter parser for Python](https://github.com/whykusanagi/celeste-cli/issues/18)
+- [ ] [#19 — Tree-sitter parser for Rust](https://github.com/whykusanagi/celeste-cli/issues/19)
+- [ ] Release workflow CGo cross-toolchain (zig-cc or native-runner matrix) so
+      pre-built binaries ship with the tree-sitter improvement instead of the stub
 
 ### Code Intelligence
 - [ ] LSP integration (go to definition, find references, rename)
-- [ ] Cross-package edge resolution improvements for the code graph
-- [ ] Per-language parser improvements (better JS/Python call extraction)
+- [ ] Automatic stale-index detection with rebuild prompt
+- [ ] Pluggable embedding-based reranker (local llama.cpp bridge / ONNX) behind the
+      existing `Reranker` interface — no cloud dependency
 
 ### Agent & Planning
 - [ ] Unified plan + todo system (plan steps auto-create todos)
@@ -34,7 +60,6 @@
 
 ### TUI
 - [ ] Proper graph visualization (graphviz integration or canvas rendering)
-- [ ] Alt-screen mode (preserve terminal scrollback on exit)
 - [ ] Session resume from TUI
 
 ### Platform

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# Celeste's Flirty Corruption Style Guide v1.8.4 – Onii-chan Approved 💋
+# Celeste's Flirty Corruption Style Guide v1.9.1 – Onii-chan Approved 💋
 
 **Translation-Failure Corruption Aesthetic - Official Style Documentation**
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# Celeste's Flirty Corruption Style Guide v1.9.1 – Onii-chan Approved 💋
+# Celeste's Flirty Corruption Style Guide v1.9.2 – Onii-chan Approved 💋
 
 **Translation-Failure Corruption Aesthetic - Official Style Documentation**
 


### PR DESCRIPTION
## Summary

Ships the persisted LSH band table for sub-linear semantic search, plus TUI command gap fixes identified during the v1.9.1 review. Five commits on top of v1.9.1 main.

## What's new

### LSH band table (the headline feature)

Implements the architecture validated in CODEGRAPH_LSH_RESEARCH.md. Instead of loading all MinHash signatures and comparing exhaustively (O(N) brute-force), precompute 64 band hashes per symbol at index time and query them at search time to retrieve a small candidate set (typically 0.1-1% of the corpus).

- **64×2 band configuration** — empirically derived for code search, where Jaccard values are 0.05-0.20 (conventional 16×8 and 32×4 produce 0% recall)
- **20× speedup at grafana scale** (77,420 symbols): 89ms brute-force → 4.3ms persisted LSH
- **Backward compatible** — pre-LSH indexes fall back to brute-force until rebuilt
- **Additive** — LSH is a pre-filter only; BM25, RRF fusion, structural rerank, and path filter are all unchanged downstream

New files: `cmd/celeste/codegraph/lsh.go` + `lsh_test.go` (8 tests). Schema: `lsh_bands(band_id, band_hash, symbol_id)` with composite index.

### TUI command gap fixes

Audit found `/index` was display-only and `/config` was read-only. Fixed:

| Command | Before | After |
|---|---|---|
| `/index rebuild` | Not available | Full re-index (populates LSH + BM25) |
| `/index update` | Not available | Incremental re-index |
| `/config set-key <k>` | Exit TUI → shell | Sets API key in-session |
| `/config set-model <m>` | Exit TUI → shell | Sets model name |
| `/config set-url <u>` | Exit TUI → shell | Sets base URL |

### Docs catch-up

All doc version stamps bumped to v1.9.2. CHANGELOG has full v1.9.0, v1.9.1, and v1.9.2 entries. ROADMAP current release updated. README codegraph feature line mentions LSH.

## Validation

- MCP end-to-end against ~/Development/site: `celeste_index status` shows 105 symbols with 6,720 LSH band rows (105 × 64), `celeste_code_search "celeste chat api proxy"` correctly returns `CelesteProxyHandler` + `handle_health_check` through the LSH path
- TUI `/index rebuild` tested live — rebuilt site index from 19/105 partial coverage to 105/105 full LSH + BM25 population
- All test suites green: codegraph, server, tui, commands
- gofmt + go vet clean

## Test plan

- [ ] CI matrix green (Test ubuntu/macos/windows, Lint, Security Scan, Docker, Build)
- [ ] After merge: user validates TUI `/index rebuild` + `/config set-model` on a live project

🤖 Generated with [Claude Code](https://claude.com/claude-code)