### PR TITLE
style: gofmt comment alignment fix

### DIFF
--- a/cmd/celeste/tui/tool_progress.go
+++ b/cmd/celeste/tui/tool_progress.go
@@ -236,9 +236,9 @@ func (m ToolProgressModel) renderEntry(e toolProgressEntry) string {
 
 // elementSpinnerIcon returns the animated icon for element-named subagents.
 // Three effects layered:
-//   1. Element kanji as the base character (instead of braille)
-//   2. Pulse: alternates bold/dim every other frame
-//   3. Corruption glitch: ~1 in 8 frames replaces kanji with a corruption glyph
+//  1. Element kanji as the base character (instead of braille)
+//  2. Pulse: alternates bold/dim every other frame
+//  3. Corruption glitch: ~1 in 8 frames replaces kanji with a corruption glyph
 func (m ToolProgressModel) elementSpinnerIcon(displayName, element string) string {
 	// Extract the kanji from displayName (first rune of "〔火 hi〕" → "火")
 	kanji := "◈" // fallback


### PR DESCRIPTION
## Summary
- Fix gofmt comment indentation in tool_progress.go (numbered list in doc comment)
- Resolves CI formatting check failure from #35 merge

## Test plan
- [x] `gofmt -l` reports no files