### PR TITLE
fix: remove unused renderMessage (lint)

### DIFF
--- a/cmd/celeste/tui/chat.go
+++ b/cmd/celeste/tui/chat.go
@@ -334,11 +334,6 @@ func (m *ChatModel) updateContent() {
 	m.viewport.SetContent(content)
 }
 
-// renderMessage renders a single chat message with Glamour markdown.
-func (m ChatModel) renderMessage(msg ChatMessage, width int) string {
-	return m.renderMessageOpt(msg, width, false)
-}
-
 // renderMessageOpt renders a chat message, optionally skipping Glamour.
 // skipMarkdown is set during the typing animation so that ANSI-styled
 // corruption glyphs at the cursor don't pass through the markdown


### PR DESCRIPTION
## Summary
- Remove unused `renderMessage` wrapper — `updateContent` now calls `renderMessageOpt` directly
- Fixes golangci-lint `unused` error from #35

## Test plan
- [x] `go build` succeeds
- [x] `golangci-lint` passes (no unused functions)