### PR TITLE
fix: resolve all golangci-lint CI errors

### DIFF
--- a/cmd/celeste/codegraph/snapshot.go
+++ b/cmd/celeste/codegraph/snapshot.go
@@ -21,18 +21,18 @@ type Snapshot struct {
 	Timestamp   time.Time         `json:"timestamp"`
 	SymbolCount int               `json:"symbol_count"`
 	EdgeCount   int               `json:"edge_count"`
-	Symbols     map[string]string `json:"symbols"`      // name → kind
-	Edges       []string          `json:"edges"`         // "source→target:kind"
+	Symbols     map[string]string `json:"symbols"` // name → kind
+	Edges       []string          `json:"edges"`   // "source→target:kind"
 }
 
 // SnapshotDiff describes what changed between two graph states.
 type SnapshotDiff struct {
-	BeforeSHA      string   `json:"before_sha"`
-	AfterSHA       string   `json:"after_sha"`
-	AddedSymbols   []string `json:"added_symbols"`
-	RemovedSymbols []string `json:"removed_symbols"`
-	AddedEdges     []string `json:"added_edges"`
-	RemovedEdges   []string `json:"removed_edges"`
+	BeforeSHA      string      `json:"before_sha"`
+	AfterSHA       string      `json:"after_sha"`
+	AddedSymbols   []string    `json:"added_symbols"`
+	RemovedSymbols []string    `json:"removed_symbols"`
+	AddedEdges     []string    `json:"added_edges"`
+	RemovedEdges   []string    `json:"removed_edges"`
 	Summary        DiffSummary `json:"summary"`
 }
 

--- a/cmd/celeste/codegraph/store_snapshot.go
+++ b/cmd/celeste/codegraph/store_snapshot.go
@@ -9,7 +9,7 @@ import (
 
 // ensureSnapshotsTable creates the snapshots table if it doesn't exist.
 func (s *Store) ensureSnapshotsTable() {
-	s.db.Exec(`CREATE TABLE IF NOT EXISTS snapshots (
+	_, _ = s.db.Exec(`CREATE TABLE IF NOT EXISTS snapshots (
 		commit_sha TEXT PRIMARY KEY,
 		created_at INTEGER NOT NULL,
 		data BLOB NOT NULL
@@ -145,14 +145,14 @@ func (s *Store) CallerCount(targetName string) int {
 		FROM edges e
 		JOIN symbols s2 ON e.target_id = s2.id
 		WHERE s2.name = ? AND e.kind = 'calls'
-	`, targetName).Scan(&count)
+	`, targetName).Scan(&count) //nolint:errcheck // best-effort count
 	return count
 }
 
 // EdgeCount returns the total number of edges connected to a symbol.
 func (s *Store) EdgeCount(name string) int {
 	var count int
-	s.db.QueryRow(`
+	_ = s.db.QueryRow(`
 		SELECT COUNT(*)
 		FROM edges e
 		JOIN symbols s ON (e.source_id = s.id OR e.target_id = s.id)
@@ -164,7 +164,7 @@ func (s *Store) EdgeCount(name string) int {
 // HasTestCoverage returns true if a symbol has any callers from test files.
 func (s *Store) HasTestCoverage(name string) bool {
 	var count int
-	s.db.QueryRow(`
+	_ = s.db.QueryRow(`
 		SELECT COUNT(*)
 		FROM edges e
 		JOIN symbols s1 ON e.source_id = s1.id

--- a/cmd/celeste/config/config.go
+++ b/cmd/celeste/config/config.go
@@ -105,7 +105,7 @@ type Config struct {
 	ConfirmActions bool `json:"confirm_actions,omitempty"`
 
 	// ElevenLabs TTS settings
-	ElevenLabsAPIKey string `json:"elevenlabs_api_key,omitempty"`
+	ElevenLabsAPIKey  string `json:"elevenlabs_api_key,omitempty"`
 	ElevenLabsVoiceID string `json:"elevenlabs_voice_id,omitempty"`
 
 	// Streaming settings

--- a/cmd/celeste/config/user_test.go
+++ b/cmd/celeste/config/user_test.go
@@ -30,7 +30,7 @@ func TestUserIdentityDisplayName(t *testing.T) {
 		{"", "Summoner", "Summoner"},
 		{"Alice", "", "Alice"},
 		{"Kusanagi", "", "Kusanagi"},
-		{"", "", "Summoner"}, // fallback
+		{"", "", "Summoner"},      // fallback
 		{"Bob", "Visitor", "Bob"}, // name takes precedence
 	}
 	for _, tt := range tests {

--- a/cmd/celeste/prompts/celeste.go
+++ b/cmd/celeste/prompts/celeste.go
@@ -55,24 +55,24 @@ var embeddedEssence []byte
 // Supports both v1.x (structured fields) and v3.x (system_prompt blob) schemas.
 type CelesteEssence struct {
 	Version     string `json:"version"`
-	Character   string `json:"character"`       // v1.x
-	Description string `json:"description"`     // v1.x
+	Character   string `json:"character"`   // v1.x
+	Description string `json:"description"` // v1.x
 	Voice       struct {
 		Style       string   `json:"style"`
 		Constraints []string `json:"constraints"`
 		EmojiUsage  string   `json:"emoji_usage"`
 		EmotesUsage string   `json:"emotes_usage"`
 	} `json:"voice"` // v1.x
-	CoreRules        []string          `json:"core_rules"`        // v1.x
-	BehaviorTiers    []BehaviorTier    `json:"behavior_tiers"`    // v1.x
-	Safety           SafetyConfig      `json:"safety"`            // v1.x
+	CoreRules        []string          `json:"core_rules"`     // v1.x
+	BehaviorTiers    []BehaviorTier    `json:"behavior_tiers"` // v1.x
+	Safety           SafetyConfig      `json:"safety"`         // v1.x
 	OperationalLaws  map[string]string `json:"operational_laws"`
 	InteractionRules []string          `json:"interaction_rules"`
 	KnowledgeUsage   string            `json:"knowledge_usage"`
 	// v3.x fields
-	SystemPrompt  string `json:"system_prompt"`   // canonical prompt blob (v3.0.0+)
-	CanonicalName string `json:"canonical_name"`  // "Celeste" (v3.0.0+)
-	CharacterID   string `json:"character_id"`    // "celeste" (v3.0.0+)
+	SystemPrompt  string `json:"system_prompt"`  // canonical prompt blob (v3.0.0+)
+	CanonicalName string `json:"canonical_name"` // "Celeste" (v3.0.0+)
+	CharacterID   string `json:"character_id"`   // "celeste" (v3.0.0+)
 }
 
 // BehaviorTier defines behavior based on score.

--- a/cmd/celeste/prompts/user_identity_test.go
+++ b/cmd/celeste/prompts/user_identity_test.go
@@ -44,8 +44,7 @@ func TestComposeUserPromptCustomName(t *testing.T) {
 		t.Fatal("should clarify user is not Kusanagi")
 	}
 	if contains(got, "twin") {
-		// The block should tell her NOT to use twin — but it shouldn't contain
-		// "twin" itself as an instruction to USE it
+		t.Log("block mentions 'twin' — acceptable if it says NOT to use it")
 	}
 }
 

--- a/cmd/celeste/subagents/manager.go
+++ b/cmd/celeste/subagents/manager.go
@@ -46,7 +46,7 @@ type SubagentRun struct {
 	Element   string    `json:"element"`           // english element (e.g., "fire")
 	Goal      string    `json:"goal"`
 	Workspace string    `json:"workspace"`
-	Status    string    `json:"status"` // "waiting", "running", "completed", "failed"
+	Status    string    `json:"status"`               // "waiting", "running", "completed", "failed"
 	DependsOn []string  `json:"depends_on,omitempty"` // task_ids that must complete first
 	Result    string    `json:"result"`
 	Error     string    `json:"error,omitempty"`
@@ -77,7 +77,7 @@ type Manager struct {
 	mu        sync.Mutex
 	runs      map[string]*SubagentRun
 	counter   int
-	isChild   bool // true if this manager is inside a subagent (blocks recursion)
+	isChild   bool        // true if this manager is inside a subagent (blocks recursion)
 	dagQueue  []*DAGEntry // tasks waiting for dependencies
 }
 
@@ -101,8 +101,8 @@ type TurnCallback func(turn int, maxTurns int, toolName string)
 type SpawnOptions struct {
 	TaskID    string       // user-assigned task ID for DAG references
 	DependsOn []string     // task IDs that must complete before this starts
-	TurnCb   TurnCallback // nested progress callback
-	MaxTurns int          // 0 = default (20)
+	TurnCb    TurnCallback // nested progress callback
+	MaxTurns  int          // 0 = default (20)
 }
 
 // Spawn creates and runs a subagent with the given goal. It blocks until the
@@ -187,9 +187,7 @@ func (m *Manager) SpawnWithOptions(ctx context.Context, goal string, workspace s
 				seen[peer.TaskID] = true
 			}
 		}
-		if len(opts.DependsOn) > 0 {
-			// DAG auto-detected (logged via TUI progress events)
-		}
+		// DAG auto-detect complete (dependencies logged via TUI progress events)
 	}
 
 	// Check if dependencies are met

--- a/cmd/celeste/tui/persona_panel.go
+++ b/cmd/celeste/tui/persona_panel.go
@@ -194,7 +194,7 @@ func (m PersonaPanelModel) View() string {
 		style := labelStyle
 		if m.cursor == i {
 			cursor = "▸ "
-			style = labelStyle.Copy().Foreground(lipgloss.Color("#d94f90"))
+			style = labelStyle.Foreground(lipgloss.Color("#d94f90"))
 		}
 
 		// Render the slider bar


### PR DESCRIPTION
## Summary
- Fix gofmt formatting in 5 files
- Fix errcheck violations in store_snapshot.go
- Fix staticcheck SA4017 (unused return), SA1019 (deprecated .Copy()), SA9003 (empty branch)

## Test plan
- [x] `go build` succeeds
- [x] All lint issues from CI run #24717912079 addressed