### PR TITLE
fix: remaining gofmt + deprecated .Copy() for CI

### DIFF
--- a/cmd/celeste/tools/builtin/tts.go
+++ b/cmd/celeste/tools/builtin/tts.go
@@ -249,12 +249,12 @@ func (t *TTSTool) Execute(ctx context.Context, input map[string]any, progress ch
 		return tools.ToolResult{
 			Content: result,
 			Metadata: map[string]any{
-				"filename":  filename,
-				"bytes":     len(audioData),
-				"text_len":  len(text),
-				"voice_id":  voiceID,
-				"ssml":      useSSML,
-				"played":    action == "speak",
+				"filename": filename,
+				"bytes":    len(audioData),
+				"text_len": len(text),
+				"voice_id": voiceID,
+				"ssml":     useSSML,
+				"played":   action == "speak",
 			},
 		}, nil
 
@@ -373,13 +373,13 @@ func (t *TTSTool) Execute(ctx context.Context, input map[string]any, progress ch
 // clipsFile represents both v1 (plain text) and v2 (SSML) clip formats.
 type clipsFile struct {
 	Clips []struct {
-		Name           string   `json:"name"`
-		Script         string   `json:"script"`
-		DurationEstimate string `json:"duration_estimate"`
-		Tags           []string `json:"tags"`
+		Name             string   `json:"name"`
+		Script           string   `json:"script"`
+		DurationEstimate string   `json:"duration_estimate"`
+		Tags             []string `json:"tags"`
 	} `json:"clips"`
-	Version      string `json:"version"`
-	Persona      string `json:"persona"`
+	Version       string `json:"version"`
+	Persona       string `json:"persona"`
 	SSMLOptimized bool   `json:"ssml_optimized"`
 }
 
@@ -526,8 +526,8 @@ func listVoices(ctx context.Context, apiKey string) (tools.ToolResult, error) {
 
 	var result struct {
 		Voices []struct {
-			VoiceID string `json:"voice_id"`
-			Name    string `json:"name"`
+			VoiceID string            `json:"voice_id"`
+			Name    string            `json:"name"`
 			Labels  map[string]string `json:"labels"`
 		} `json:"voices"`
 	}
@@ -885,8 +885,9 @@ func probeDuration(filename string) float64 {
 // stripTagsAndCues removes SSML/XML tags and bracketed action cues from text.
 // ElevenLabs v3 speaks these as literal words — they need to be removed.
 // Examples: <prosody rate="slow">text</prosody> → text
-//           [laughs] → (removed)
-//           [whispers] text [/whispers] → text
+//
+//	[laughs] → (removed)
+//	[whispers] text [/whispers] → text
 func stripTagsAndCues(text string) string {
 	// Strip XML/SSML tags
 	result := text

--- a/cmd/celeste/tools/builtin/tts_project.go
+++ b/cmd/celeste/tools/builtin/tts_project.go
@@ -29,13 +29,13 @@ type AudioProject struct {
 
 // AudioTrack is a single audio element on the timeline.
 type AudioTrack struct {
-	File   string  `json:"file"`              // path to audio file
-	Role   string  `json:"role"`              // "voice", "bed", "sfx" — determines behavior
-	Volume float64 `json:"volume"`            // 0.0-1.0
-	Start  float64 `json:"start"`             // start time in seconds on timeline
-	End    float64 `json:"end,omitempty"`     // optional: cut at this second (0 = play full)
-	Loop   bool    `json:"loop,omitempty"`    // loop for full output duration (beds only)
-	Label  string  `json:"label,omitempty"`   // human-readable label for progress display
+	File   string  `json:"file"`            // path to audio file
+	Role   string  `json:"role"`            // "voice", "bed", "sfx" — determines behavior
+	Volume float64 `json:"volume"`          // 0.0-1.0
+	Start  float64 `json:"start"`           // start time in seconds on timeline
+	End    float64 `json:"end,omitempty"`   // optional: cut at this second (0 = play full)
+	Loop   bool    `json:"loop,omitempty"`  // loop for full output duration (beds only)
+	Label  string  `json:"label,omitempty"` // human-readable label for progress display
 }
 
 // AudioProjectTool handles the project-based render pipeline.

--- a/cmd/celeste/tui/persona_panel.go
+++ b/cmd/celeste/tui/persona_panel.go
@@ -241,7 +241,7 @@ func (m PersonaPanelModel) View() string {
 	}
 	r18Name := labelStyle.Render("R18 Toggle")
 	if m.cursor == 4 {
-		r18Name = labelStyle.Copy().Foreground(lipgloss.Color("#d94f90")).Render("R18 Toggle")
+		r18Name = labelStyle.Foreground(lipgloss.Color("#d94f90")).Render("R18 Toggle")
 	}
 	sb.WriteString(fmt.Sprintf("%s%s %s\n", r18Cursor, r18Name, r18Style.Render(r18Label)))
 


### PR DESCRIPTION
## Summary
- gofmt: tts.go, tts_project.go
- staticcheck SA1019: last `.Copy()` call in persona_panel.go line 244

## Test plan
- [x] `gofmt -l` clean
- [x] `grep .Copy() persona_panel.go` returns nothing
- [x] `go build` succeeds