### PR TITLE
fix: restore missing content policy refusal patterns

### DIFF
--- a/cmd/celeste/commands/commands.go
+++ b/cmd/celeste/commands/commands.go
@@ -937,6 +937,10 @@ func IsContentPolicyRefusal(response string) bool {
 	refusalPatterns := []string{
 		"i can't assist",
 		"i cannot assist",
+		"i can't create",
+		"i cannot create",
+		"i can't generate",
+		"i cannot generate",
 		"i can't help with",
 		"i cannot help with",
 		"i'm not able to",


### PR DESCRIPTION
## Summary
- Restores `i can't/cannot create` and `i can't/cannot generate` patterns
- These were dropped when tightening detection in #35
- Length gate (>600 chars) still prevents false positives on story content
- Fixes `TestIsContentPolicyRefusal/cannot_create` test failure

## Test plan
- [x] `TestIsContentPolicyRefusal` — all 6 subtests pass locally