### PR TITLE
fix(ci): version tests use serverVersion constant + stop double-running CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ '**' ]   # run CI on every branch push (dev feedback before a PR exists)
-  pull_request:
-    branches: [ main ]
+    branches: [ main ]   # post-merge sanity on main
+  pull_request:          # every PR (incl. dev branches + Dependabot) gets CI — the gate
+  workflow_dispatch:     # manual re-run for a flaky check
 
-# Cancel superseded runs for the same ref so a rapid push sequence doesn't pile up.
+# Cancel superseded runs for the same PR/ref so new commits don't pile up runs.
+# Keyed on the PR head SHA when available so a branch push and its PR don't both run.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/cmd/celeste/server/handlers_test.go
+++ b/cmd/celeste/server/handlers_test.go
@@ -137,7 +137,7 @@ func TestCelesteStatusHandler(t *testing.T) {
 	if !strings.Contains(text, "celeste") {
 		t.Fatal("status should contain server name")
 	}
-	if !strings.Contains(text, "1.10.0") {
+	if !strings.Contains(text, serverVersion) {
 		t.Fatal("status should contain server version")
 	}
 	if !strings.Contains(text, "test-model") {

--- a/cmd/celeste/server/server_test.go
+++ b/cmd/celeste/server/server_test.go
@@ -59,8 +59,8 @@ func TestHandleInitialize(t *testing.T) {
 	if serverInfo["name"] != "celeste" {
 		t.Fatalf("expected server name 'celeste', got %v", serverInfo["name"])
 	}
-	if serverInfo["version"] != "1.10.0" {
-		t.Fatalf("expected server version '1.10.0', got %v", serverInfo["version"])
+	if serverInfo["version"] != serverVersion {
+		t.Fatalf("expected server version %q, got %v", serverVersion, serverInfo["version"])
 	}
 }
 


### PR DESCRIPTION
Fixes the two things behind the "cancelled / failed checks" churn after the v1.10.0 release + Dependabot/release-please going live.

## 1. release-please PR was failing the required Test check (real)
release-please's Release PR (#70) bumps the version constants via the `x-release-please-version` annotation, but `server_test.go` / `handlers_test.go` asserted the **literal** `"1.10.0"` → Test failed on all 3 OS. Now they compare against the **`serverVersion` constant**, so any version bump keeps tests green. (Future-proofs every release-please PR.)

## 2. CI was double-running every branch (the cancellation herd)
The `push: ['**']` trigger ran CI on *both* the branch push and its PR. With 9 Dependabot PRs opening at once, that produced a pile of duplicate + concurrency-cancelled runs. Changed to:
- `push: [main]` (post-merge sanity) + `pull_request:` (the gate — every PR incl. dev branches & Dependabot still gets CI)
- `workflow_dispatch` for manually re-running a flaky check
- concurrency keyed on PR number

Dev-branch CI still happens — via the PR (open a draft PR for pre-review CI), without the double-run.

Tests + build green locally; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)